### PR TITLE
Fixed app.yaml and testrtc.py location to work on real appengine.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -6,19 +6,19 @@ api_version: 1
 
 handlers:
 - url: /manual
-  static_dir: manual
+  static_dir: src/manual
 
 - url: /js
-  static_dir: js
+  static_dir: src/js
 
 - url: /css
-  static_dir: css
+  static_dir: src/css
 
 - url: /bower_components/testrtc/ui
-  static_dir: ui
+  static_dir: src/ui
 
 - url: /bower_components
-  static_dir: ../bower_components
+  static_dir: bower_components
 
 - url: /.*
   script: testrtc.app

--- a/testrtc.py
+++ b/testrtc.py
@@ -23,7 +23,7 @@ random_file = bytearray([random.randint(0,127) for i in xrange(0,10000)] * 1000)
 class MainPage(webapp2.RequestHandler):
   """The main UI page, renders the 'index.html' template."""
   def get(self):
-    template = jinja_environment.get_template('index.html')
+    template = jinja_environment.get_template('src/index.html')
     content = template.render({})
     self.response.out.write(content)
 


### PR DESCRIPTION
The previous setting worked on a local appengine, but not in the real deploy as app.yaml cannot reference files not under the directory it is served from.
