### PR TITLE
Allow devices with only 1 media device type and possibilty to continue without any media devices

### DIFF
--- a/src/css/main_nolint.css
+++ b/src/css/main_nolint.css
@@ -11,7 +11,6 @@ html /deep/ core-icon[icon="av:videocam-off"] {
   color: #888;
 }
 
-html /deep/ paper-dialog,
-html /deep/ paper-action-dialog {
+html /deep/ paper-dialog {
   top: 2em;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -27,7 +27,6 @@
   <link rel="import" href="components/core-icons/av-icons.html">
   <link rel="import" href="components/core-collapse/core-collapse.html">
   <link rel="import" href="components/paper-dialog/paper-dialog.html">
-  <link rel="import" href="components/paper-dialog/paper-action-dialog.html">
   <link rel="import" href="components/paper-dialog/paper-dialog-transition.html">
   <link rel="import" href="components/paper-progress/paper-progress.html">
   <link rel="import" href="components/paper-button/paper-button.html">

--- a/src/index.html
+++ b/src/index.html
@@ -61,8 +61,8 @@
   <paper-dialog id="gum-pending-dialog"
                 heading="Welcome to WebRTC Troubleshooter"
                 backdrop autoCloseDisabled>
-    <p>To test your webcam, microphone, and speakers we need permission to
-        them selecting by “Allow”.</p>
+    <p>To test your webcam, microphone and speakers we need permission to use
+      them, approve by selecting “Allow”.</p>
   </paper-dialog>
 
   <!-- GetUserMedia error dialog -->
@@ -74,6 +74,7 @@
       camera and microphone.</p>
     <p>GetUserMedia reason: <span id="gum-error-message"></span></p>
     <paper-icon-button icon="bug-report" onclick="report.open()">File a bug</paper-icon-button>
+    <paper-button id="gum-bypass" onclick="this.parentElement.close()">Continue without audio or video</paper-button>
   </paper-dialog>
 
   <!-- GetUserMedia not supported dialog -->
@@ -90,6 +91,7 @@
                 backdrop autoCloseDisabled>
     <p>Your device does not have any audio or video devices connected.
       Please, plug a microphone or a camera into your device.</p>
+  <paper-button id="gum-bypass" onclick="this.parentElement.close()">Continue without audio or video</paper-button>
   </paper-dialog>
 
   <!-- Settings dialog -->

--- a/src/index.html
+++ b/src/index.html
@@ -72,8 +72,10 @@
       icon in the URL bar above to give TestRTC access to your computer's
       camera and microphone.</p>
     <p>GetUserMedia reason: <span id="gum-error-message"></span></p>
-    <paper-icon-button icon="bug-report" onclick="report.open()">File a bug</paper-icon-button>
-    <paper-button id="gum-bypass" onclick="this.parentElement.close()">Continue without audio or video</paper-button>
+    <div horizontal justified layout>
+      <paper-button onclick="report.open()">File a bug</paper-button>
+      <paper-button id="gum-bypass" onclick="this.parentElement.parentElement.close()">Continue without audio and/or video</paper-button>
+    </div>
   </paper-dialog>
 
   <!-- GetUserMedia not supported dialog -->

--- a/src/js/bandwidth_test.js
+++ b/src/js/bandwidth_test.js
@@ -117,7 +117,7 @@ function testVideoBandwidth(config) {
   // tracked on: https://code.google.com/p/webrtc/issues/detail?id=3050
   call.disableVideoFec();
 
-  doGetUserMedia({audio: false, video: true}, gotStream, reportFatal);
+  doGetUserMedia({audio: false, video: true}, gotStream);
 
   function gotStream(stream) {
     call.pc1.addStream(stream);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -332,7 +332,7 @@ function doGetUserMedia(constraints, onSuccess, onFail) {
     if (onFail) {
       onFail.apply(this, arguments);
     } else {
-      reportFatal('Failed to get access to local media. Error name was ' +
+      reportFatal('Failed to get access to local media due to error: ' +
                   error.name);
     }
   };


### PR DESCRIPTION
Some users only have one media device, either camera or microphone. This allows them to continue and test will fail as usual.

Also added a bypass button allowing the user to continue when no devices are detected or permission has been denied which will allow at least the majority of network tests to be run.

Did some small cleanups as well.

Fixes #31 