### PR TITLE
Add log file upload and download mechanism using blobstore

### DIFF
--- a/cron.yml
+++ b/cron.yml
@@ -1,0 +1,4 @@
+cron:
+- description: Cleanup blobstore files.
+  url: /tasks/blobstore/clean
+  schedule: every 24 hours

--- a/src/css/main_nolint.css
+++ b/src/css/main_nolint.css
@@ -14,3 +14,25 @@ html /deep/ core-icon[icon="av:videocam-off"] {
 html /deep/ paper-dialog {
   top: 2em;
 }
+
+html /deep/ paper-button {
+  font-weight: 400;
+}
+
+html /deep/ paper-dialog#mainDialog {
+  max-width: 50%;
+}
+
+html /deep/ paper-dialog#failure,
+html /deep/ paper-dialog#success {
+  top: 9em;
+  max-width: 60%;
+}
+
+@media only all and (max-device-width: 700px) {
+  html /deep/ paper-dialog#success,
+  html /deep/ paper-dialog#failure,
+  html /deep/ paper-dialog#mainDialog {
+    font-size: 0.6em;
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -28,8 +28,6 @@
   <link rel="import" href="components/core-collapse/core-collapse.html">
   <link rel="import" href="components/paper-dialog/paper-dialog.html">
   <link rel="import" href="components/paper-dialog/paper-dialog-transition.html">
-  <link rel="import" href="components/paper-input/paper-input.html">
-  <link rel="import" href="components/paper-input/paper-autogrow-textarea.html">
   <link rel="import" href="components/paper-progress/paper-progress.html">
   <link rel="import" href="components/paper-button/paper-button.html">
   <link rel="import" href="components/paper-icon-button/paper-icon-button.html">
@@ -69,8 +67,7 @@
   </paper-dialog>
 
   <!-- Bug report dialog -->
-  <report-dialog>
-  </report-dialog>
+  <report-dialog></report-dialog>
 
   <!-- Add common files after this line. -->
   <script src="js/report.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -28,11 +28,14 @@
   <link rel="import" href="components/core-collapse/core-collapse.html">
   <link rel="import" href="components/paper-dialog/paper-dialog.html">
   <link rel="import" href="components/paper-dialog/paper-dialog-transition.html">
+  <link rel="import" href="components/paper-input/paper-input.html">
+  <link rel="import" href="components/paper-input/paper-autogrow-textarea.html">
   <link rel="import" href="components/paper-progress/paper-progress.html">
   <link rel="import" href="components/paper-button/paper-button.html">
   <link rel="import" href="components/paper-icon-button/paper-icon-button.html">
   <link rel="import" href="components/testrtc/ui/line-chart.html">
   <link rel="import" href="components/testrtc/ui/gum-dialog.html">
+  <link rel="import" href="components/testrtc/ui/report-dialog.html">
 
   <!-- Google Analytics -->
   <script>
@@ -65,12 +68,9 @@
     <div class="select"><label>Video source: <select id="videoSource"></select></label></div>
   </paper-dialog>
 
-  <!-- Report dialog -->
-  <paper-dialog id="report-dialog" heading="Bug Report" backdrop autoCloseDisabled transition="paper-dialog-transition-center">
-    <p>Please file a bug in the <a id="report-link">Chromium bug tracker</a> and attach the report from this page.</p>
-    <paper-button id="report-download" onclick="report.downloadReport()">Download Report</paper-button>
-    <paper-button onclick="this.parentElement.close()">Close</paper-button>
-  </paper-dialog>
+  <!-- Bug report dialog -->
+  <report-dialog>
+  </report-dialog>
 
   <!-- Add common files after this line. -->
   <script src="js/report.js"></script>

--- a/src/js/report.js
+++ b/src/js/report.js
@@ -27,18 +27,6 @@ Report.prototype = {
     document.querySelector('report-dialog').open();
   },
 
-  // Clears the log and adds sytem-info from the device.
-  clearLog_: function() {
-    this.output_ = [];
-    this.traceEventInstant('system-info', Report.getSystemInfo());
-  },
-
-  traceEventHeader: function(name, args) {
-    this.output_.unshift({'ts': Date.now(),
-                          'name': name,
-                          'args': args});
-  },
-
   traceEventInstant: function(name, args) {
     this.output_.push({'ts': Date.now(),
                        'name': name,
@@ -69,21 +57,27 @@ Report.prototype = {
   },
 
   generateBugReport_: function(bugDescription) {
-    this.traceEventHeader('description', bugDescription);
-    this.traceEventHeader('title', 'WebRTC Troubleshooter bug report');
-    return this.getContent_();
+    var header = {'title': 'WebRTC Troubleshooter bug report',
+                  'description': bugDescription || null};
+    return this.getContent_(header);
   },
 
   // Returns the logs into a JSON formated string that is a list of events
   // similar to the way chrome devtools format uses. The final string is
   // manually composed to have newlines between the entries is being easier
-  // to parse by human eyes.
-  getContent_: function() {
+  // to parse by human eyes. If a contentHead object argument is provided it
+  // will be added at the top of the log file.
+  getContent_: function(contentHead) {
     var stringArray = [];
-    for (var i = 0; i !== this.output_.length; ++i) {
-      stringArray.push(JSON.stringify(this.output_[i]));
-    }
+    this.appendEventsAsString_([contentHead] || [], stringArray);
+    this.appendEventsAsString_(this.output_, stringArray);
     return '[' + stringArray.join(',\n') + ']';
+  },
+
+  appendEventsAsString_: function(events, output) {
+    for (var i = 0; i !== events.length; ++i) {
+      output.push(JSON.stringify(events[i]));
+    }
   },
 
   onWindowError_: function(error) {

--- a/src/ui/report-dialog.html
+++ b/src/ui/report-dialog.html
@@ -8,6 +8,8 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../paper-dialog/paper-dialog.html">
 <link rel="import" href="../../paper-button/paper-button.html">
+<link rel="import" href="../../paper-input/paper-autogrow-textarea.html">
+<link rel="import" href="../../paper-input/paper-input.html">
 
 <polymer-element name="report-dialog">
   <template>
@@ -56,8 +58,6 @@
 
       onGetUploadUrl_: function(response) {
         if (response.currentTarget.status === 200) {
-          report.traceEventInstant('log', 'onGetUploadUrl succeeded.');
-
           // Create report file.
           var fileName = 'testrtc-' + new Date().toJSON() + '.log';
           var fileContent = report.generateBugReport_(this.description);
@@ -74,8 +74,7 @@
           xhr.send(formData);
         } else {
           this.reportError = response.currentTarget.status;
-          report.traceEventInstant('log', 'onGetUploadUrl failed: ' +
-              this.reportError);
+          report.traceEventInstant('log-error', {error: this.reportError});
           this.$.failure.open();
         }
       },
@@ -84,14 +83,12 @@
         if (response.currentTarget.status === 200) {
           this.reportUrl =
               response.currentTarget.getResponseHeader('response-text');
-          // Clear bug report.
-          report.clearLog_();
+          report.traceEventInstant('log-uploaded', {url: this.reportUrl});
           this.$.success.open();
         } else {
           this.reportError = response.currentTarget.status;
-          report.traceEventInstant('log', 'onUploadFile_ failed: ' +
-              this.reportError);
-           this.$.failure.open();
+          report.traceEventInstant('log-error', {error: this.reportError});
+          this.$.failure.open();
         }
       },
 

--- a/src/ui/report-dialog.html
+++ b/src/ui/report-dialog.html
@@ -1,0 +1,115 @@
+<!--
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+-->
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../paper-dialog/paper-dialog.html">
+<link rel="import" href="../../paper-button/paper-button.html">
+
+<polymer-element name="report-dialog">
+  <template>
+    <!-- Report dialog -->
+    <paper-dialog id="mainDialog" heading="File a bug" autoCloseDisabled backdrop transition="paper-dialog-transition-center"
+    closeSelector="[dismissive]">
+      <paper-input-decorator floatingLabel label="Describe your issue here">
+        <paper-autogrow-textarea id="textAreaAutoGrow">
+          <textarea id="textArea" value="{{description}}"></textarea>
+        </paper-autogrow-textarea>
+      </paper-input-decorator>
+      <h3>Disclaimer</h3>
+      <p>The report will contain information about your device including network information that is useful to troubleshoot the issue and will be available for a period of 90 days.</p>
+      <paper-button affirmative on-tap="{{upload}}" disabled="{{submitting}}">Upload report</paper-button>
+      <paper-button dismissive disabled="{{submitting}}">Cancel</paper-button>
+    </paper-dialog>
+
+    <!-- Report upload success -->
+    <paper-dialog id="success" heading="Success" autoCloseDisabled transition="paper-dialog-transition-center" closeSelector="[affirmative]">
+      <p><a href="{{reportUrl}}">This is the link to your report</a></p>
+      <paper-button on-tap="{{closeSuccess}}">Close</paper-button>
+    </paper-action-dialog>
+
+    <!-- Report failure success -->
+    <paper-dialog id="failure" heading="Failure" autoCloseDisabled transition="paper-dialog-transition-center" closeSelector="[affirmative]">
+      <p>Upload failed with error: {{reportError}}</p>
+      <p>Check your network connection</p>
+      <paper-button affirmative on-tap="{{closeFail}}">Close</paper-button>
+    </paper-dialog>
+  </template>
+  <script>
+    Polymer('report-dialog', {
+      open: function() {
+        this.$.mainDialog.open();
+      },
+
+      upload: function() {
+        this.submitting = true;
+
+        // Get unique upload url from server.
+        var xhr = new XMLHttpRequest();
+        xhr.open('HEAD', '/report/new', true);
+        xhr.addEventListener('load', this.onGetUploadUrl_.bind(this), false);
+        xhr.send(null);
+      },
+
+      onGetUploadUrl_: function(response) {
+        if (response.currentTarget.status === 200) {
+          report.traceEventInstant('log', 'onGetUploadUrl succeeded.');
+
+          // Create report file.
+          var fileName = 'testrtc-' + new Date().toJSON() + '.log';
+          var fileContent = report.generateBugReport_(this.description);
+          var blob = new Blob([fileContent], {type: 'text/plain'});
+          var formData = new FormData();
+          formData.append(fileName, blob, fileName);
+
+          // Upload the report file using the URL in the response-text header.
+          var url = response.currentTarget.getResponseHeader('response-text');
+          var xhr = new XMLHttpRequest();
+          xhr.open('POST', url, true);
+          xhr.setRequestHeader('X-File-Name', fileName);
+          xhr.addEventListener('load', this.onUploadFile_.bind(this), false);
+          xhr.send(formData);
+        } else {
+          this.reportError = response.currentTarget.status;
+          report.traceEventInstant('log', 'onGetUploadUrl failed: ' +
+              this.reportError);
+          this.$.failure.open();
+        }
+      },
+
+      onUploadFile_: function(response) {
+        if (response.currentTarget.status === 200) {
+          this.reportUrl =
+              response.currentTarget.getResponseHeader('response-text');
+          // Clear bug report.
+          report.clearLog_();
+          this.$.success.open();
+        } else {
+          this.reportError = response.currentTarget.status;
+          report.traceEventInstant('log', 'onUploadFile_ failed: ' +
+              this.reportError);
+           this.$.failure.open();
+        }
+      },
+
+      closeFail: function() {
+        this.submitting = false;
+        this.$.failure.close();
+      },
+
+      closeSuccess: function() {
+        this.submitting = false;
+        this.description = null;
+        // Workaround to get the label to float correctly on the line.
+        // https://github.com/Polymer/paper-input/issues/137.
+        this.$.textArea.focus();
+        this.$.textAreaAutoGrow.update();
+        this.$.success.close();
+        this.$.mainDialog.close();
+      }
+    });
+  </script>
+</polymer-element>

--- a/testrtc.py
+++ b/testrtc.py
@@ -1,17 +1,23 @@
-#!/usr/bin/python2.4
+#!/usr/bin/python
 #
 # Copyright 2014 Google Inc. All Rights Reserved.
 
-"""WebRTC Test
-
-This module serves the WebRTC Test Page.
 """
-
+This module handles log file upload and download, delete log files from the
+    blobstore (only allowed via a cron job) at a set interval and also creates
+    a 10Mb downloadable file useful for bandwidth benchmarking.
+"""
 import cgi
 import logging
 import random
 import os
 import webapp2
+import urllib
+import datetime
+import re
+
+from google.appengine.ext import blobstore
+from google.appengine.ext.webapp import blobstore_handlers
 
 # Generate 10 kilobytes of random data and create a 10MB buffer from it.
 random_file = bytearray([random.randint(0,127) for i in xrange(0,10000)] * 1000)
@@ -21,7 +27,42 @@ class TestDownloadFile(webapp2.RequestHandler):
     self.response.headers.add_header("Access-Control-Allow-Origin", "*")
     self.response.headers['Content-Type'] = 'application/octet-stream'
     self.response.out.write(random_file[0: int(size_kbytes)*1000])
-    
+
+class NewReportHandler(blobstore_handlers.BlobstoreUploadHandler):
+  # Generate and return blobstore upload URL.
+  def head(self):
+    upload_url = blobstore.create_upload_url('/report/new')
+    self.response.headers['Response-Text'] = upload_url
+
+  # On uploaded file to the blobstore.
+  def post(self):
+    origin = self.request.headers['Origin']
+    fileName = self.request.headers['X-File-Name']
+    upload_files = self.get_uploads(field_name=fileName)
+    blob_info = upload_files[0]
+    self.response.headers['Response-Text'] = origin + '/report/%s' % blob_info.key()
+
+class ReportHandler(blobstore_handlers.BlobstoreDownloadHandler):
+  def get(self, resource):
+    resource = str(urllib.unquote(resource))
+    blob_info = blobstore.BlobInfo.get(resource)
+    self.send_blob(blob_info)
+
+# Remove log files equal or older than retentionPeriod.
+class CleanBlobstore(blobstore_handlers.BlobstoreUploadHandler):
+  def get(self):
+    retentionPeriod = datetime.datetime.now() - datetime.timedelta(days=90)
+    gqlQuery = blobstore.BlobInfo.gql("WHERE creation <= :date",
+        date = datetime.datetime.now() <= retentionPeriod)
+    logFiles = gqlQuery.run()
+    for log in logFiles:
+      # Make sure to only delete log reports from the blobstore.
+      if re.match(r'testrtc-.*.log', log.filename):
+        blobstore.BlobInfo.get(log.key()).delete()
+
 app = webapp2.WSGIApplication([
+    ('/report/new', NewReportHandler),
+    ('/report/([^/]+)', ReportHandler),
     (r'/test-download-file/(\d?\d00)KB.data', TestDownloadFile),
+    ('/tasks/blobstore/clean', CleanBlobstore)
   ], debug=True)


### PR DESCRIPTION
* Summary of changes:
 * Creates a file blob of type text/plain
 * Fetches the Blobstore upload URL in a HEAD request
 * Uploads the file blob in a form-data POST request using the URL from aforementioned HEAD request/response.
 * Log download URL is appended to the Chromium bug report template.
 * File bug/upload file button is disabled after successful upload. Closing the bug report dialog resets this state and opening the bug report dialog again allows the user to upload a log file and file a new bug.
 * GAE Cron job setup to clean logs older than 30 days every 24h.

* Questions:
 * Should we restrict access to the log files? Can add admin only access on the serve/ handler (GAE admin).
 * Currently opens a new tab to the Chromium bug tracker when filing a bug, this can be blocked by the popup blocker. Is this acceptable?