### PR TITLE
Mictestfix

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -427,11 +427,17 @@ function setTimeoutWithProgressBar(timeoutCallback, timeoutMs) {
     setTestProgress((now - start) * 100 / timeoutMs);
   }, 100);
 
-  setTimeout(function() {
+  var timeoutTask = function() {
     clearInterval(updateProgressBar);
     setTestProgress(100);
     timeoutCallback();
-  }, timeoutMs);
+  };
+  var timer = setTimeout(timeoutTask, timeoutMs);
+  var finishProgressBar = function() {
+    clearTimeout(timer);
+    timeoutTask();
+  };
+  return finishProgressBar;
 }
 
 // Parse URL parameters and configure test filters.

--- a/src/js/mictest.js
+++ b/src/js/mictest.js
@@ -197,7 +197,7 @@ MicTest.prototype = {
       var l = buffersL[j];
       var r = buffersR[j];
       var d = 0.0;
-      if (l.length == r.length) {
+      if (l.length === r.length) {
         for (var i = 0; i < l.length; i++) {
           d = Math.abs(l[i] - r[i]);
           if (d > this.monoDetectThreshold) {

--- a/src/js/mictest.js
+++ b/src/js/mictest.js
@@ -197,11 +197,15 @@ MicTest.prototype = {
       var l = buffersL[j];
       var r = buffersR[j];
       var d = 0.0;
-      for (var i = 0; i < l.length; i++) {
-        d = Math.abs(l[i] - r[i]);
-        if (d > this.monoDetectThreshold) {
-          diffSamples++;
+      if (l.length == r.length) {
+        for (var i = 0; i < l.length; i++) {
+          d = Math.abs(l[i] - r[i]);
+          if (d > this.monoDetectThreshold) {
+            diffSamples++;
+          }
         }
+      } else {
+        diffSamples++;
       }
     }
     if (diffSamples > 0) {

--- a/src/js/mictest.js
+++ b/src/js/mictest.js
@@ -33,7 +33,7 @@ function MicTest() {
   // Data must be identical within one LSB 16-bit to be identified as mono.
   this.monoDetectThreshold = 1.0 / 65536;
   // Number of consequtive clipThreshold level samples that indicate clipping.
-  this.clipCountThreshold = 4;
+  this.clipCountThreshold = 6;
   this.clipThreshold = 1.0;
 
   // Populated with audio as a 3-dimensional array:
@@ -88,9 +88,7 @@ MicTest.prototype = {
   collectAudio: function(event) {
     // Simple silence detection: check first and last sample of each channel in
     // the buffer. If both are below a threshold, the buffer is considered
-    // silent. Non-silent buffers are copied for analysis. Note that the silent
-    // detection will likely cause the stored stream to contain discontinuities,
-    // but that is ok for our needs here (just looking at levels).
+    // silent.
     var sampleCount = event.inputBuffer.length;
     var allSilent = true;
     for (var c = 0; c < event.inputBuffer.numberOfChannels; c++) {
@@ -99,10 +97,15 @@ MicTest.prototype = {
       var last = Math.abs(data[sampleCount - 1]);
       var newBuffer;
       if (first > this.silentThreshold || last > this.silentThreshold) {
+        // Non-silent buffers are copied for analysis. Note that the silent
+        // detection will likely cause the stored stream to contain discontinu-
+        // ities, but that is ok for our needs here (just looking at levels).
         newBuffer = new Float32Array(sampleCount);
         newBuffer.set(data);
         allSilent = false;
       } else {
+        // Silent buffers are not copied, but we store empty buffers so that the
+        // analysis doesn't have to care.
         newBuffer = new Float32Array();
       }
       this.collectedAudio[c].push(newBuffer);
@@ -165,6 +168,9 @@ MicTest.prototype = {
             clipCount = 0;
           }
         }
+        // RMS is calculated over each buffer, meaning the integration time will
+        // be different depending on sample rate and buffer size. In practise
+        // this should be a small problem.
         rms = Math.sqrt(rms / samples.length);
         maxRms = Math.max(maxRms, rms);
       }
@@ -174,8 +180,8 @@ MicTest.prototype = {
       var dBPeak = this.dBFS(maxPeak);
       var dBRms = this.dBFS(maxRms);
       reportInfo('Channel ' + channelNumber + ' levels: ' +
-                 dBPeak.toFixed(2) + ' dB (peak), ' +
-                 dBRms.toFixed(2) + ' dB (RMS)');
+                 dBPeak.toFixed(1) + ' dB (peak), ' +
+                 dBRms.toFixed(1) + ' dB (RMS)');
       if (dBRms < this.lowVolumeThreshold) {
         reportError('Microphone input level is low, increase input ' +
                     'volume or move closer to the microphone.');
@@ -196,8 +202,8 @@ MicTest.prototype = {
     for (var j = 0; j < buffersL.length; j++) {
       var l = buffersL[j];
       var r = buffersR[j];
-      var d = 0.0;
       if (l.length === r.length) {
+        var d = 0.0;
         for (var i = 0; i < l.length; i++) {
           d = Math.abs(l[i] - r[i]);
           if (d > this.monoDetectThreshold) {


### PR DESCRIPTION
- Allow progress bars to be cancelled.
- Mic test will run for up to 5s, or until 2s of non-silent audio has been collected.
- Collect and analyze more than the very last input buffer.
- Compute peak level, maximum RMS level and detect clipping.
- Improved mono signal detection.
