### PR TITLE
Change back webcomponents to 0.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   ],
   "license": "BSD-3-Clause",
   "dependencies": {
-    "webcomponentsjs": "Polymer/webcomponentsjs#^0.6.0",
+    "webcomponentsjs": "Polymer/webcomponentsjs#^0.5.0",
     "core-toolbar": "Polymer/core-toolbar#^0.5.0",
     "core-icon-button": "Polymer/core-icon-button#^0.5.0",
     "core-icon": "Polymer/core-icon#^0.5.0",

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,8 @@
   ],
   "license": "BSD-3-Clause",
   "dependencies": {
-    "webcomponentsjs": "Polymer/webcomponentsjs#^0.5.0",
+    "polymer": "Polymer/polymer#0.5.5",
+    "webcomponentsjs": "Polymer/webcomponentsjs#0.5.5",
     "core-toolbar": "Polymer/core-toolbar#^0.5.0",
     "core-icon-button": "Polymer/core-icon-button#^0.5.0",
     "core-icon": "Polymer/core-icon#^0.5.0",


### PR DESCRIPTION
Fixes #89 

I just needed to select a specific webcomponents version during bower update.

Question is if I need to pin webcomponents to 0.5.5 due to bower not being able to select a version while installing and might pick up 0.6.3 which will break polymer.

Trying 0.5.0 first, then I'll pin to 0.5.5 if it does not work.