### PR TITLE
Use Promise and mediaDevices in favor of getSources

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -36,7 +36,8 @@ document.querySelector('gum-dialog').addEventListener('closed', function() {
   navigator.mediaDevices.enumerateDevices()
   .then(gotSources)
   .catch(function(err) {
-      console.log('JS Device selection not supported', err);});
+    console.log('JS Device selection not supported', err);
+  });
 
   startButton.removeAttribute('disabled');
 });

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -31,12 +31,13 @@ var testSuites = [];
 var testFilters = [];
 var currentTest;
 
+// Populate the device selection drop down menu after the gUM dialog closes.
 document.querySelector('gum-dialog').addEventListener('closed', function() {
-  if (typeof MediaStreamTrack.getSources === 'undefined') {
-    console.log('getSources is not supported, device selection not possible.');
-  } else {
-    MediaStreamTrack.getSources(gotSources);
-  }
+  navigator.mediaDevices.enumerateDevices()
+  .then(gotSources)
+  .catch(function(err) {
+      console.log('JS Device selection not supported', err);});
+
   startButton.removeAttribute('disabled');
 });
 
@@ -375,16 +376,16 @@ function gotSources(sourceInfos) {
   for (var i = 0; i !== sourceInfos.length; ++i) {
     var sourceInfo = sourceInfos[i];
     var option = document.createElement('option');
-    option.value = sourceInfo.id;
+    option.value = sourceInfo.deviceId;
     appendOption(sourceInfo, option);
   }
 }
 
 function appendOption(sourceInfo, option) {
-  if (sourceInfo.kind === 'audio') {
+  if (sourceInfo.kind === 'audioinput') {
     option.text = sourceInfo.label || 'microphone ' + (audioSelect.length + 1);
     audioSelect.appendChild(option);
-  } else if (sourceInfo.kind === 'video') {
+  } else if (sourceInfo.kind === 'videoinput') {
     option.text = sourceInfo.label || 'camera ' + (videoSelect.length + 1);
     videoSelect.appendChild(option);
   } else {

--- a/src/ui/gum-handler.html
+++ b/src/ui/gum-handler.html
@@ -35,11 +35,15 @@ visible on the page but is no more it will keep polling permissions once per sec
         return;
       }
 
-      if (typeof MediaStreamTrack.getSources !== 'undefined') {
-        MediaStreamTrack.getSources(this.triggerGetUserMediaBasedOnSources_.bind(this));
-      } else {
-        this.triggerGetUserMediaBasedOnSources_([]);
-      }
+      // Since triggerGetUserMediaBasedOnSources handles sources.length = 0
+      // we call upon it regardless of a enumerate device failure. Using the
+      // .catch callback for to get the logs. This is due to sources.length = 0
+      // does not necessarily mean JS device selection is unsupported.
+      navigator.mediaDevices.enumerateDevices()
+      .then(this.triggerGetUserMediaBasedOnSources_.bind(this))
+      .catch(function(err) {
+          console.log('JS Device selection not supported', err)
+          this.triggerGetUserMediaBasedOnSources_.bind(this);});
     },
 
     triggerGetUserMediaBasedOnSources_: function(sources) {
@@ -48,10 +52,10 @@ visible on the page but is no more it will keep polling permissions once per sec
         constraints = {audio: true, video: true};
       } else {
         for (var i = 0; i < sources.length; i++) {
-          if (sources[i].kind === 'audio') {
+          if (sources[i].kind === 'audioinput') {
             constraints.audio = true;
           }
-          if (sources[i].kind === 'video') {
+          if (sources[i].kind === 'videoinput') {
             constraints.video = true;
           }
         }

--- a/src/ui/gum-handler.html
+++ b/src/ui/gum-handler.html
@@ -42,8 +42,9 @@ visible on the page but is no more it will keep polling permissions once per sec
       navigator.mediaDevices.enumerateDevices()
       .then(this.triggerGetUserMediaBasedOnSources_.bind(this))
       .catch(function(err) {
-          console.log('JS Device selection not supported', err)
-          this.triggerGetUserMediaBasedOnSources_.bind(this);});
+        console.log('JS Device selection not supported', err)
+        this.triggerGetUserMediaBasedOnSources_.bind(this);
+      });
     },
 
     triggerGetUserMediaBasedOnSources_: function(sources) {


### PR DESCRIPTION
Adapter.js now takes care of the shimming of navigator.mediaDevices if it does not exist, it returns real getSources objects if it exist otherwise fake getSources formatted source objects.

It also supports Promise for several methods, including getUserMedia, will look into that in a separate PR.

This enables device selection in Firefox as well, one weird thing though is that Firefox only returns one set of devices, not all that are available on the system. Also not sure if it provides device labels (empty string on HTTP even after gUM approval), will check HTTPS to see if it's works there.