### PR TITLE
Add build functionality via grunt

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": ".."
+  "directory": "components"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 components
 node_modules
+out

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ node_js:
   - 0.10
 
 install:
-  - npm install -g bower grunt grunt-cli vulcanize@0.7.10
-  - npm install grunt-jscs grunt-contrib-jshint grunt-htmlhint grunt-contrib-csslint
+  - npm install
   - bower update
 
 script:
   - grunt
-  - vulcanize --inline -strip src/index.html
+  - grunt build

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
             'components/webrtc-adapter/adapter.js'
             ],
             dest: 'out',
-            nonull:true,
+            nonull: true,
             expand: true
           }
         ]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,6 +6,42 @@ module.exports = function(grunt) {
 
   // configure project
   grunt.initConfig({
+    copy: {
+      build: {
+        cwd: '.',
+        files: [
+          {src: [
+            'cron.yml',
+            'app.yaml',
+            'src/manual/**',
+            'components/webrtc-adapter/adapter.js'
+            ],
+            dest: 'out',
+            nonull:true,
+            expand: true
+          }
+        ]
+      }
+    },
+
+    clean: {
+      build: {
+        src: ['out/*']
+      }
+    },
+
+    vulcanize: {
+      default: {
+        options: {
+          inline: true,
+          strip: true
+        },
+        files: {
+          'out/src/index.html': 'src/index.html'
+        }
+      }
+    },
+
     csslint: {
       options: {
         csslintrc: 'build/csslintrc'
@@ -18,7 +54,8 @@ module.exports = function(grunt) {
           '**/*.css',
           '!**/*_nolint.css',
           '!components/**',
-          '!node_modules/**'
+          '!node_modules/**',
+          '!out/**'
         ]
       }
     },
@@ -29,7 +66,8 @@ module.exports = function(grunt) {
           // TODO: fix rule and enable html linting.
           '!**/*.html',
           '!components/**',
-          '!node_modules/**'
+          '!node_modules/**',
+          '!out/**'
         ]
       }
     },
@@ -40,7 +78,8 @@ module.exports = function(grunt) {
         preset: 'google', // as per Google style guide – could use '.jscsrc' instead
         excludeFiles: [
           'components/**',
-          'node_modules/**'
+          'node_modules/**',
+          'out/**'
         ]
       }
     },
@@ -49,11 +88,12 @@ module.exports = function(grunt) {
       options: {
         ignores: [
           'components/**',
-          'node_modules/**'
+          'node_modules/**',
+          'out/**'
         ],
         jshintrc: 'build/jshintrc'
       },
-      // files to validate
+      // Files to validate
       // can choose more than one name + array of paths
       // usage with this name: grunt jshint:files
       files: ['**/*.js']
@@ -65,7 +105,14 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-htmlhint');
   grunt.loadNpmTasks('grunt-jscs');
   grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-vulcanize');
+  grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-contrib-clean');
 
-  // set default tasks to run when grunt is called without parameters
+  // Set default tasks to run when grunt is called without parameters
   grunt.registerTask('default', ['csslint', 'htmlhint', 'jscs', 'jshint']);
+
+  // Cleans out/ folder, copies files in place and vulcanizes index.html to out/.
+  grunt.registerTask('build', ['clean', 'copy', 'vulcanize']);
 };

--- a/README.md
+++ b/README.md
@@ -56,33 +56,33 @@ Patches and issues welcome! See [CONTRIBUTING](https://github.com/GoogleChrome/w
 ## Development ##
 Make sure to install NodeJS and NPM before continuing. Note that we have been mainly been using Posix when developing TestRTC hence developer tools might not work correctly on Windows.
 
-Install developer tools and frameworks
+#### Install developer tools and frameworks ####
 ```bash
 npm install
 ```
 
-Install dependencies
+#### Install dependencies ####
 ```bash
 bower update
 ```
 
-Run linters (currently very limited set is run)
+#### Run linters (currently very limited set is run) ####
 ```bash
 grunt
 ```
 
-Build testrtc
-* Cleans out/ folder if it exists else it's created, then it copies and vulcanizes the resources needed to deploy this on Google App Engine.
+#### Build testrtc ####
+Cleans out/ folder if it exists else it's created, then it copies and vulcanizes the resources needed to deploy this on Google App Engine.
 ```
 grunt build
 ```
 
-Run non vulcanized version of TestRTC using (Google App Engine SDK for Python)(https://cloud.google.com/appengine/downloads). This is useful while developing.
+#### Run non vulcanized version of TestRTC using (Google App Engine SDK for Python)(https://cloud.google.com/appengine/downloads). This is useful while developing. ####
 ```bash
 python dev_appserver.py app.yml
 ```
 
-Run vulcanized version of TestRTC using (Google App Engine SDK for Python)(https://cloud.google.com/appengine/downloads) (Requires the Build testrtc step to be performed first).
+#### Run vulcanized version of TestRTC using (Google App Engine SDK for Python)(https://cloud.google.com/appengine/downloads) (Requires the Build testrtc step to be performed first). ####
 ```bash
 python dev_appserver.py out/app.yml
 ```

--- a/README.md
+++ b/README.md
@@ -53,3 +53,36 @@ Due to their time duration they are not part of the normal test suite and need t
 ## Contributing ##
 Patches and issues welcome! See [CONTRIBUTING](https://github.com/GoogleChrome/webrtc/blob/master/CONTRIBUTING.md) for instructions. All contributors must sign a contributor license agreement before code can be accepted. Please complete the agreement for an [individual](https://developers.google.com/open-source/cla/individual) or a [corporation](https://developers.google.com/open-source/cla/corporate) as appropriate. The [Developer's Guide](https://bit.ly/webrtcdevguide) for this repo has more information about code style, structure and validation.
 
+## Development ##
+Make sure to install NodeJS and NPM before continuing. Note that we have been mainly been using Posix when developing TestRTC hence developer tools might not work correctly on Windows.
+
+Install developer tools and frameworks
+```bash
+npm install
+```
+
+Install dependencies
+```bash
+bower update
+```
+
+Run linters (currently very limited set is run)
+```bash
+grunt
+```
+
+Build testrtc
+* Cleans out/ folder if it exists else it's created, then it copies and vulcanizes the resources needed to deploy this on Google App Engine.
+```
+grunt build
+```
+
+Run non vulcanized version of TestRTC using (Google App Engine SDK for Python)(https://cloud.google.com/appengine/downloads). This is useful while developing.
+```bash
+python dev_appserver.py app.yml
+```
+
+Run vulcanized version of TestRTC using (Google App Engine SDK for Python)(https://cloud.google.com/appengine/downloads) (Requires the Build testrtc step to be performed first).
+```bash
+python dev_appserver.py out/app.yml
+```

--- a/app.yaml
+++ b/app.yaml
@@ -18,6 +18,18 @@ handlers:
   static_dir: src/manual
   secure: always
 
+- url: /components
+  static_dir: components
+  secure: always
+
+- url: /js
+  static_dir: src/js
+  secure: always
+
+- url: /ui
+  static_dir: src/ui
+  secure: always
+
 - url: /images
   static_files: src/images
   upload: src/images
@@ -28,8 +40,8 @@ handlers:
   secure: always
 
 - url: /
-  static_files: src/vulcanized.html
-  upload: src/vulcanized.html
+  static_files: src/index.html
+  upload: src/index.html
   secure: always
 
 - url: /.*

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "TestRTC",
+  "description": "Collection of tests and tools to help diagnose WebRTC systems.",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/webrtc/testrtc"
+  },
+  "authors": [
+    "The WebRTC project authors (http://www.webrtc.org/)"
+  ],
+  "devDependencies": {
+    "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-copy": "~0.8.0",
+    "grunt-contrib-csslint": "~0.4.0",
+    "grunt-jscs": "~1.8.0",
+    "grunt-contrib-jshint": "~0.11.2",
+    "grunt-htmlhint": "~0.4.1",
+    "grunt-cli": "~0.1.13",
+    "grunt-vulcanize": "~0.6.4",
+    "vulcanize": "~0.7.10",
+    "grunt": "~0.4.5",
+    "bower": "~1.4.1"
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -31,17 +31,17 @@
     ga('send', 'pageview');
   </script>
 
-  <script src="../../webrtc-adapter/adapter.js"></script>
-  <script src="../../webcomponentsjs/webcomponents.js"></script>
-  <link rel="import" href="../../core-toolbar/core-toolbar.html">
-  <link rel="import" href="../../core-icon/core-icon.html">
-  <link rel="import" href="../../core-icons/av-icons.html">
-  <link rel="import" href="../../core-collapse/core-collapse.html">
-  <link rel="import" href="../../paper-dialog/paper-dialog.html">
-  <link rel="import" href="../../paper-dialog/paper-dialog-transition.html">
-  <link rel="import" href="../../paper-progress/paper-progress.html">
-  <link rel="import" href="../../paper-button/paper-button.html">
-  <link rel="import" href="../../paper-icon-button/paper-icon-button.html">
+  <script src="../components/webrtc-adapter/adapter.js"></script>
+  <script src="../components/webcomponentsjs/webcomponents.js"></script>
+  <link rel="import" href="../components/core-toolbar/core-toolbar.html">
+  <link rel="import" href="../components/core-icon/core-icon.html">
+  <link rel="import" href="../components/core-icons/av-icons.html">
+  <link rel="import" href="../components/core-collapse/core-collapse.html">
+  <link rel="import" href="../components/paper-dialog/paper-dialog.html">
+  <link rel="import" href="../components/paper-dialog/paper-dialog-transition.html">
+  <link rel="import" href="../components/paper-progress/paper-progress.html">
+  <link rel="import" href="../components/paper-button/paper-button.html">
+  <link rel="import" href="../components/paper-icon-button/paper-icon-button.html">
   <link rel="import" href="ui/line-chart.html">
   <link rel="import" href="ui/gum-dialog.html">
   <link rel="import" href="ui/report-dialog.html">

--- a/src/manual/audio-and-video/index.html
+++ b/src/manual/audio-and-video/index.html
@@ -13,7 +13,7 @@
   <title>Single Local Preview (Video and Audio)</title>
   <meta http-equiv="X-UA-Compatible" content="chrome=1"/>
   <!-- Load the polyfill to switch-hit between Chrome and Firefox -->
-  <script src="../../../../components/webrtc-adapter/adapter.js"></script>
+  <script src="../../../components/webrtc-adapter/adapter.js"></script>
   <script type="text/javascript">
   function requestVideoAndAudio() {
     // Call into getUserMedia via the polyfill (adapter.js).

--- a/src/manual/multiple-audio/index.html
+++ b/src/manual/multiple-audio/index.html
@@ -13,7 +13,7 @@
   <title>Multiple Local Preview (Audio Only)</title>
   <meta http-equiv="X-UA-Compatible" content="chrome=1"/>
   <!-- Load the polyfill to switch-hit between Chrome and Firefox -->
-  <script src="../../../../components/webrtc-adapter/adapter.js"></script>
+  <script src="../../../components/webrtc-adapter/adapter.js"></script>
   <script type="text/javascript">
   function requestAudio() {
     // Call into getUserMedia via the polyfill (adapter.js).

--- a/src/manual/multiple-peerconnections/index.html
+++ b/src/manual/multiple-peerconnections/index.html
@@ -49,7 +49,7 @@
       </td>
     </tr>
   </table>
-  <script src="../../../../components/webrtc-adapter/adapter.js"></script>
+  <script src="../../../components/webrtc-adapter/adapter.js"></script>
   <script src="js/main.js"></script>
 </body>
 </html>

--- a/src/manual/multiple-video-devices/index.html
+++ b/src/manual/multiple-video-devices/index.html
@@ -25,7 +25,7 @@
   </div>
   <div id="messages"></div>
    <!-- Load the polyfill to switch-hit between Chrome and Firefox -->
-  <script src="../../../../components/webrtc-adapter/adapter.js"></script>
+  <script src="../../../components/webrtc-adapter/adapter.js"></script>
   <script src="js/main.js"></script>
 </body>
 </html>

--- a/src/manual/multiple-video/index.html
+++ b/src/manual/multiple-video/index.html
@@ -47,7 +47,7 @@
           autoplay="autoplay"></video></td>
     </tr>
   </table>
-  <script src="../../../../components/webrtc-adapter/adapter.js"></script>
+  <script src="../../../components/webrtc-adapter/adapter.js"></script>
   <script type="text/javascript">
     function requestVideo() {
       // Call into getUserMedia via the polyfill (adapter.js).

--- a/src/manual/peer2peer/index.html
+++ b/src/manual/peer2peer/index.html
@@ -193,7 +193,7 @@
 
   </div>
 </div>
-  <script src="../../../../components/webrtc-adapter/adapter.js"></script>
+  <script src="../../../components/webrtc-adapter/adapter.js"></script>
   <script src="js/main.js"></script>
 </body>
 </html>

--- a/src/manual/single-audio/index.html
+++ b/src/manual/single-audio/index.html
@@ -13,7 +13,7 @@
   <title>Single Local Preview (Audio Only)</title>
   <meta http-equiv="X-UA-Compatible" content="chrome=1"/>
   <!-- Load the polyfill to switch-hit between Chrome and Firefox -->
-  <script src="../../../../components/webrtc-adapter/adapter.js"></script>
+  <script src="../../../components/webrtc-adapter/adapter.js"></script>
   <script type="text/javascript">
   function requestAudio() {
     getUserMedia({video: false, audio: true},

--- a/src/manual/single-video/index.html
+++ b/src/manual/single-video/index.html
@@ -13,7 +13,7 @@
   <title>Single Local Preview (Video Only)</title>
   <meta http-equiv="X-UA-Compatible" content="chrome=1"/>
   <!-- Load the polyfill to switch-hit between Chrome and Firefox -->
-  <script src="../../../../components/webrtc-adapter/adapter.js"></script>
+  <script src="../../../components/webrtc-adapter/adapter.js"></script>
   <script type="text/javascript">
   function requestVideo() {
     getUserMedia({video: true, audio: false},

--- a/src/ui/gum-dialog.html
+++ b/src/ui/gum-dialog.html
@@ -22,11 +22,11 @@ For now it serves as an example on how to build a UI flow on top of gum-handler.
 
 TODO(andresp): Delay showing the dialog (probably using transitions).
 -->
-<link rel="import" href="../../../polymer/polymer.html">
-<link rel="import" href="../../../core-icon/core-icon.html">
-<link rel="import" href="../../../core-icons/av-icons.html">
-<link rel="import" href="../../../paper-dialog/paper-dialog.html">
-<link rel="import" href="../../../paper-button/paper-button.html">
+<link rel="import" href="../../components/polymer/polymer.html">
+<link rel="import" href="../../components/core-icon/core-icon.html">
+<link rel="import" href="../../components/core-icons/av-icons.html">
+<link rel="import" href="../../components/paper-dialog/paper-dialog.html">
+<link rel="import" href="../../components/paper-button/paper-button.html">
 <link rel="import" href="gum-handler.html">
 
 <polymer-element name="gum-dialog" attributes="pending heading">

--- a/src/ui/gum-handler.html
+++ b/src/ui/gum-handler.html
@@ -15,7 +15,7 @@ TODO(andresp): Need a mechanism to stop polling permissions? E.g. if it was temp
 visible on the page but is no more it will keep polling permissions once per second.
 -->
 
-<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../components/polymer/polymer.html">
 <polymer-element name="gum-handler" attributes="pending error">
 <script>
   Polymer('gum-handler', {

--- a/src/ui/line-chart.html
+++ b/src/ui/line-chart.html
@@ -14,7 +14,7 @@ It is not a very advanced or a pretty line chart render, but it is very
 specialized for the testrtc use case where delaying the JS thread incurs delays
 on measuring the round-trip time.
 -->
-<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../components/polymer/polymer.html">
 <polymer-element name="line-chart">
   <template>
     <div style="width:300px; margin:auto;">

--- a/src/ui/report-dialog.html
+++ b/src/ui/report-dialog.html
@@ -5,11 +5,11 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
 -->
-<link rel="import" href="../../../polymer/polymer.html">
-<link rel="import" href="../../../paper-dialog/paper-action-dialog.html">
-<link rel="import" href="../../../paper-button/paper-button.html">
-<link rel="import" href="../../../paper-input/paper-autogrow-textarea.html">
-<link rel="import" href="../../../paper-input/paper-input.html">
+<link rel="import" href="../../components/polymer/polymer.html">
+<link rel="import" href="../../components/paper-dialog/paper-action-dialog.html">
+<link rel="import" href="../../components/paper-button/paper-button.html">
+<link rel="import" href="../../components/paper-input/paper-autogrow-textarea.html">
+<link rel="import" href="../../components/paper-input/paper-input.html">
 
 <polymer-element name="report-dialog">
   <template>


### PR DESCRIPTION
* Add back package.json so it's more convenient setting up the repo using "npm install"
* Change bower components folder to the components/ in the repo root folder rather than outside the repo, this was done to keep the same folder structure for both the vulcanized and non vulcanized version.
* Add grunt build steps that copies all necessary files to deploy and vulcanizes index.html in a out/ folder.
* The previous bullet and the one before enables developing on an non vulcanized index.html version in src/ (start GAE using the app.yaml in the root) and after running "grunt build" you can run the vulcanized version locally in out/ (start GAE using the app.yaml in out/).
* Fixes #81.

