### PR TITLE
Add absolut path so that vulcanize uses the correct path

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -16,7 +16,7 @@
   <base target="_blank">
   <title>WebRTC Troubleshooter</title>
 
-  <link rel="icon" type="image/png" href="images/webrtc-icon-192x192.png" />
+  <link rel="icon" type="image/png" href="/images/webrtc-icon-192x192.png" />
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700">
   <link rel="stylesheet" href="css/main.css" />
   <link rel="stylesheet" href="css/main_nolint.css" />


### PR DESCRIPTION
Without this the path after vulcanize is set to src/images/webrtc-icon...... rather than /images/webrtc-icon which causes a 500.