### PR TITLE
add testrtc.py to Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,7 @@ module.exports = function(grunt) {
           {src: [
             'cron.yml',
             'app.yaml',
+            'testrtc.py',
             'src/manual/**',
             'components/webrtc-adapter/adapter.js'
             ],


### PR DESCRIPTION
Forgot to add the testrtc.py to the build script which handles the bug reporting on the GAE side.

Fixes #101 