### PR TITLE
Use polymer#1.0.9 until #1.1.0+ works in Firefox

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   ],
   "license": "BSD-3-Clause",
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.0.9",
+    "polymer": "Polymer/polymer#1.0.9",
     "webrtc-adapter": "webrtc/adapter#~0.1.6",
     "paper-toolbar": "PolymerElements/paper-toolbar#~1.0.3",
     "iron-icon": "PolymerElements/iron-icon#~1.0.2",

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   ],
   "license": "BSD-3-Clause",
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.0.0",
+    "polymer": "Polymer/polymer#^1.0.9",
     "webrtc-adapter": "webrtc/adapter#~0.1.6",
     "paper-toolbar": "PolymerElements/paper-toolbar#~1.0.3",
     "iron-icon": "PolymerElements/iron-icon#~1.0.2",


### PR DESCRIPTION
Currently polymer#1.1.0 does not work in Firefox, I filed an issue in the polymer repo, lets see what they say. Anyway, this will make sure we use polymer#1.0.9 until it works 

*Note: Ignore the branch name (I was going to add more logging when I realized I had forgotten to run bower updated and voila I could reproduce the issue locally as well;))