### PR TITLE
Test more webrtc connectivity scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,19 @@ create a temporary link with the report result.
     * Reports encode time and average framerate
   * Check supported resolutions
     * Lists resolutions that appear to be supported
-* Connectivity
-  * Udp/Tcp connectivity
+* Network
+  * Udp/Tcp
     * Verifies it can talk with a turn server with the given protocol
   * IPv6 connectivity
     * Verifies it can gather at least one IPv6 candidate
+* Connectivity
+  * Relay
+    * Verifies connections can be established between peers through a TURN server
+  * Reflexive
+    * Verifies connections can be established between peers through NAT
+  * Host
+    * Verifies connections can be established between peers with the same IP address
+* Throughput
   * Data throughput
     * Establishes a loopback call and tests data channels throughput on the link
   * Video bandwidth

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   ],
   "license": "BSD-3-Clause",
   "dependencies": {
-    "polymer": "Polymer/polymer#1.0.9",
+    "polymer": "Polymer/polymer#1.1.2",
     "webrtc-adapter": "webrtc/adapter#~0.1.6",
     "paper-toolbar": "PolymerElements/paper-toolbar#~1.0.3",
     "iron-icon": "PolymerElements/iron-icon#~1.0.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "The WebRTC project authors (http://www.webrtc.org/)"
   ],
   "scripts": {
-    "test": "grunt build && test/run-tests"
+    "test": "grunt build && test/run-tests",
+    "build": "grunt build",
+    "lint": "grunt"
   },
   "devDependencies": {
     "grunt-contrib-clean": "~0.6.0",

--- a/src/index.html
+++ b/src/index.html
@@ -60,6 +60,7 @@
   <!-- Add tests after this line. -->
   <script src="js/mictest.js"></script>
   <script src="js/camresolutionstest.js"></script>
+  <script src="js/nettest.js"></script>
   <script src="js/conntest.js"></script>
   <script src="js/bandwidth_test.js"></script>
 </body>

--- a/src/js/bandwidth_test.js
+++ b/src/js/bandwidth_test.js
@@ -10,7 +10,7 @@
 // Creates a loopback via relay candidates and tries to send as many packets
 // with 1024 chars as possible while keeping dataChannel bufferedAmmount above
 // zero.
-addTest(testSuiteName.CONNECTIVITY, testCaseName.DATATHROUGHPUT,
+addTest(testSuiteName.THROUGHPUT, testCaseName.DATATHROUGHPUT,
   Call.asyncCreateTurnConfig.bind(null, dataChannelThroughputTest,
                                   reportFatal));
 
@@ -97,7 +97,7 @@ function dataChannelThroughputTest(config) {
 // relay candidates for 40 seconds. Computes rtt and bandwidth estimation
 // average and maximum as well as time to ramp up (defined as reaching 75% of
 // the max bitrate. It reports infinite time to ramp up if never reaches it.
-addTest(testSuiteName.CONNECTIVITY, testCaseName.VIDEOBANDWIDTH,
+addTest(testSuiteName.THROUGHPUT, testCaseName.VIDEOBANDWIDTH,
   Call.asyncCreateTurnConfig.bind(null, videoBandwidthTest, reportFatal));
 
 function videoBandwidthTest(config) {
@@ -190,11 +190,11 @@ function videoBandwidthTest(config) {
   }
 }
 
-addExplicitTest(testSuiteName.CONNECTIVITY, testCaseName.NETWORKLATENCY,
+addExplicitTest(testSuiteName.THROUGHPUT, testCaseName.NETWORKLATENCY,
   Call.asyncCreateTurnConfig.bind(null, wiFiPeriodicScanTest.bind(null,
       Call.isNotHostCandidate), reportFatal));
 
-addExplicitTest(testSuiteName.CONNECTIVITY, testCaseName.NETWORKLATENCYRELAY,
+addExplicitTest(testSuiteName.THROUGHPUT, testCaseName.NETWORKLATENCYRELAY,
   Call.asyncCreateTurnConfig.bind(null, wiFiPeriodicScanTest.bind(null,
       Call.isRelay), reportFatal));
 

--- a/src/js/call.js
+++ b/src/js/call.js
@@ -123,6 +123,14 @@ Call.isNotHostCandidate = function(candidate) {
   return candidate.type !== 'host';
 };
 
+Call.isReflexive = function(candidate) {
+  return candidate.type === 'srflx';
+};
+
+Call.isHost = function(candidate) {
+  return candidate.type === 'host';
+};
+
 Call.isIpv6 = function(candidate) {
   return candidate.address.indexOf(':') !== -1;
 };

--- a/src/js/call.js
+++ b/src/js/call.js
@@ -194,3 +194,25 @@ Call.fetchCEODTurnConfig_ = function(onSuccess, onError) {
   xhr.open('GET', Call.CEOD_URL, true);
   xhr.send();
 };
+
+// Get a STUN config, either from settings or the provided default
+Call.createStunConfig = function() {
+  var urls = [
+    'stun:stun.l.google.com:19302',
+    'stun:stun1.l.google.com:19302',
+    'stun:stun2.l.google.com:19302',
+    'stun:stun3.l.google.com:19302',
+    'stun:stun4.l.google.com:19302'
+  ];
+  var settings = currentTest.settings;
+  if (settings.stunURI) {
+    urls = settings.stunURI.split(',');
+  }
+  return {
+    iceServers: [
+      {
+        urls: urls
+      }
+    ]
+  };
+};

--- a/src/js/call.js
+++ b/src/js/call.js
@@ -147,7 +147,7 @@ Call.parseCandidate = function(text) {
   };
 };
 
-// Get a TURN a config, either from settings or from CEOD.
+// Get a TURN config, either from settings or from CEOD.
 Call.asyncCreateTurnConfig = function(onSuccess, onError) {
   var settings = currentTest.settings;
   if (typeof(settings.turnURI) === 'string' && settings.turnURI !== '') {

--- a/src/js/call.js
+++ b/src/js/call.js
@@ -25,7 +25,7 @@ function Call(config) {
 Call.prototype = {
   establishConnection: function() {
     this.traceEvent({state: 'start'});
-    this.pc1.createOffer(this.gotOffer_.bind(this));
+    this.pc1.createOffer(this.gotOffer_.bind(this), reportFatal);
   },
 
   close: function() {
@@ -88,7 +88,7 @@ Call.prototype = {
     }
     this.pc1.setLocalDescription(offer);
     this.pc2.setRemoteDescription(offer);
-    this.pc2.createAnswer(this.gotAnswer_.bind(this));
+    this.pc2.createAnswer(this.gotAnswer_.bind(this), reportFatal);
   },
 
   gotAnswer_: function(answer) {

--- a/src/js/conntest.js
+++ b/src/js/conntest.js
@@ -7,100 +7,59 @@
  */
 'use strict';
 
-addTest(testSuiteName.CONNECTIVITY, testCaseName.UDPCONNECTIVITY,
-    udpConnectivityTest);
-addTest(testSuiteName.CONNECTIVITY, testCaseName.TCPCONNECTIVITY,
-    tcpConnectivityTest);
-addTest(testSuiteName.CONNECTIVITY, testCaseName.IPV6ENABLED,
-    hasIpv6CandidatesTest);
+addTest(testSuiteName.CONNECTIVITY, testCaseName.RELAYCONNECTIVITY,
+    relayConnectivityTest);
+addTest(testSuiteName.CONNECTIVITY, testCaseName.REFLEXIVECONNECTIVITY,
+    reflexiveConnectivityTest);
+addTest(testSuiteName.CONNECTIVITY, testCaseName.HOSTCONNECTIVITY,
+    hostConnectivityTest);
 
-// Test whether it can connect via UDP to a TURN server
-// Get a TURN config, and try to get a relay candidate using UDP.
-function udpConnectivityTest() {
+function relayConnectivityTest() {
   Call.asyncCreateTurnConfig(
-      function(config) {
-        filterConfig(config, 'udp');
-        gatherCandidates(config, null, Call.isRelay);
-      },
-      reportFatal);
+    runConnectivityTest.bind(null, Call.isRelay),
+    reportFatal);
 }
 
-// Test whether it can connect via TCP to a TURN server
-// Get a TURN config, and try to get a relay candidate using TCP.
-function tcpConnectivityTest() {
-  Call.asyncCreateTurnConfig(
-      function(config) {
-        filterConfig(config, 'tcp');
-        gatherCandidates(config, null, Call.isRelay);
-      },
-      reportFatal);
-}
-
-// Test whether it is IPv6 enabled (TODO: test IPv6 to a destination).
-// Turn on IPv6, and try to get an IPv6 host candidate.
-function hasIpv6CandidatesTest() {
-  var params = {optional: [{googIPv6: true}]};
-  gatherCandidates(null, params, Call.isIpv6);
-}
-
-// Filter the RTCConfiguration |config| to only contain URLs with the
-// specified transport protocol |protocol|. If no turn transport is
-// specified it is added with the requested protocol.
-function filterConfig(config, protocol) {
-  var transport = 'transport=' + protocol;
-  for (var i = 0; i < config.iceServers.length; ++i) {
-    var iceServer = config.iceServers[i];
-    var newUrls = [];
-    for (var j = 0; j < iceServer.urls.length; ++j) {
-      var uri = iceServer.urls[j];
-      if (uri.indexOf(transport) !== -1) {
-        newUrls.push(uri);
-      } else if (uri.indexOf('?transport=') === -1 && uri.startsWith('turn')) {
-        newUrls.push(uri + '?' + transport);
+function reflexiveConnectivityTest() {
+  runConnectivityTest(Call.isReflexive, {
+    iceServers: [
+      {
+        urls: [
+          'stun:23.21.150.121'
+        ]
       }
-    }
-    iceServer.urls = newUrls;
-  }
+    ]
+  });
 }
 
-// Create a PeerConnection, and gather candidates using RTCConfig |config|
-// and ctor params |params|. Succeed if any candidates pass the |isGood|
-// check, fail if we complete gathering without any passing.
-function gatherCandidates(config, params, isGood) {
-  var pc;
-  try {
-    pc = new RTCPeerConnection(config, params);
-  } catch (error) {
-    return reportFatal('Fail to create peer connection: ' + error);
-  }
+function hostConnectivityTest() {
+  runConnectivityTest(Call.isHost);
+}
 
-  // In our candidate callback, stop if we get a candidate that passes |isGood|.
-  pc.onicecandidate = function(e) {
-    // Once we've decided, ignore future callbacks.
-    if (pc.signalingState === 'closed') {
-      return;
-    }
-
-    if (e.candidate) {
-      var parsed = Call.parseCandidate(e.candidate.candidate);
-      if (isGood(parsed)) {
-        reportSuccess('Gathered candidate with type: ' + parsed.type +
-                      ' address: ' + parsed.address);
-        pc.close();
-        setTestFinished();
-      }
+function runConnectivityTest(iceCandidateFilter, config) {
+  var call = new Call(config);
+  call.setIceCandidateFilter(iceCandidateFilter);
+  call.pc1.channel = call.pc1.createDataChannel(null);
+  call.pc1.channel.addEventListener('open', function() {
+    call.pc1.channel.send('hello');
+  });
+  call.pc1.channel.addEventListener('message', function(event) {
+    if (event.data !== 'world') {
+      reportFatal();
     } else {
-      pc.close();
-      reportFatal('Failed to gather specified candidates');
+      reportSuccess('Data successfully transmitted between peers.');
+      setTestFinished();
     }
-  };
-
-  // Create an audio-only, recvonly offer, and setLD with it.
-  // This will trigger candidate gathering.
-  var createOfferParams = {mandatory: {OfferToReceiveAudio: true}};
-  pc.createOffer(function(offer) { pc.setLocalDescription(offer, noop, noop) ;},
-                 noop, createOfferParams);
-}
-
-function noop() {
+  });
+  call.pc2.addEventListener('datachannel', function(event) {
+    call.pc2.channel = event.channel;
+    call.pc2.channel.addEventListener('message', function(event) {
+      if (event.data !== 'hello') {
+        reportFatal();
+      } else {
+        call.pc2.channel.send('world');
+      }
+    });
+  });
+  call.establishConnection();
 }

--- a/src/js/conntest.js
+++ b/src/js/conntest.js
@@ -21,8 +21,7 @@ var timeout = null;
 // (packets travel through the public internet)
 function relayConnectivityTest() {
   Call.asyncCreateTurnConfig(
-    runConnectivityTest.bind(null, Call.isRelay),
-    reportFatal);
+    runConnectivityTest.bind(null, Call.isRelay), reportFatal);
 }
 
 // Set up a datachannel between two peers through a public IP address

--- a/src/js/conntest.js
+++ b/src/js/conntest.js
@@ -14,6 +14,8 @@ addTest(testSuiteName.CONNECTIVITY, testCaseName.REFLEXIVECONNECTIVITY,
 addTest(testSuiteName.CONNECTIVITY, testCaseName.HOSTCONNECTIVITY,
     hostConnectivityTest);
 
+var timeout = null;
+
 function relayConnectivityTest() {
   Call.asyncCreateTurnConfig(
     runConnectivityTest.bind(null, Call.isRelay),
@@ -44,6 +46,7 @@ function runConnectivityTest(iceCandidateFilter, config) {
     call.pc1.channel.send('hello');
   });
   call.pc1.channel.addEventListener('message', function(event) {
+    clearTimeout(timeout);
     if (event.data !== 'world') {
       reportFatal();
     } else {
@@ -55,6 +58,7 @@ function runConnectivityTest(iceCandidateFilter, config) {
     call.pc2.channel = event.channel;
     call.pc2.channel.addEventListener('message', function(event) {
       if (event.data !== 'hello') {
+        clearTimeout(timeout);
         reportFatal();
       } else {
         call.pc2.channel.send('world');
@@ -62,4 +66,5 @@ function runConnectivityTest(iceCandidateFilter, config) {
     });
   });
   call.establishConnection();
+  timeout = setTimeout(reportFatal.bind(null, 'Timed out'), 2000);
 }

--- a/src/js/conntest.js
+++ b/src/js/conntest.js
@@ -16,12 +16,18 @@ addTest(testSuiteName.CONNECTIVITY, testCaseName.HOSTCONNECTIVITY,
 
 var timeout = null;
 
+// Set up a datachannel between two peers through a relay
+// and verify data can be transmitted and received
+// (packets travel through the public internet)
 function relayConnectivityTest() {
   Call.asyncCreateTurnConfig(
     runConnectivityTest.bind(null, Call.isRelay),
     reportFatal);
 }
 
+// Set up a datachannel between two peers through a public IP address
+// and verify data can be transmitted and received
+// (packets should stay on the link if behind a router doing NAT)
 function reflexiveConnectivityTest() {
   runConnectivityTest(Call.isReflexive, {
     iceServers: [
@@ -34,6 +40,9 @@ function reflexiveConnectivityTest() {
   });
 }
 
+// Set up a datachannel between two peers through a local IP address
+// and verify data can be transmitted and received
+// (packets should not leave the machine running the test)
 function hostConnectivityTest() {
   runConnectivityTest(Call.isHost);
 }

--- a/src/js/conntest.js
+++ b/src/js/conntest.js
@@ -28,15 +28,7 @@ function relayConnectivityTest() {
 // and verify data can be transmitted and received
 // (packets should stay on the link if behind a router doing NAT)
 function reflexiveConnectivityTest() {
-  runConnectivityTest(Call.isReflexive, {
-    iceServers: [
-      {
-        urls: [
-          'stun:stun.l.google.com:19302'
-        ]
-      }
-    ]
-  });
+  runConnectivityTest(Call.isReflexive, Call.createStunConfig());
 }
 
 // Set up a datachannel between two peers through a local IP address

--- a/src/js/conntest.js
+++ b/src/js/conntest.js
@@ -28,7 +28,8 @@ function relayConnectivityTest() {
 // and verify data can be transmitted and received
 // (packets should stay on the link if behind a router doing NAT)
 function reflexiveConnectivityTest() {
-  runConnectivityTest(Call.isReflexive, Call.createStunConfig());
+  Call.asyncCreateStunConfig(
+    runConnectivityTest.bind(null, Call.isReflexive), reportFatal);
 }
 
 // Set up a datachannel between two peers through a local IP address

--- a/src/js/conntest.js
+++ b/src/js/conntest.js
@@ -27,7 +27,7 @@ function reflexiveConnectivityTest() {
     iceServers: [
       {
         urls: [
-          'stun:23.21.150.121'
+          'stun:stun.l.google.com:19302'
         ]
       }
     ]

--- a/src/js/conntest.js
+++ b/src/js/conntest.js
@@ -49,11 +49,11 @@ function hostConnectivityTest() {
 function runConnectivityTest(iceCandidateFilter, config) {
   var call = new Call(config);
   call.setIceCandidateFilter(iceCandidateFilter);
-  call.pc1.channel = call.pc1.createDataChannel(null);
-  call.pc1.channel.addEventListener('open', function() {
-    call.pc1.channel.send('hello');
+  var ch1 = call.pc1.createDataChannel(null);
+  ch1.addEventListener('open', function() {
+    ch1.send('hello');
   });
-  call.pc1.channel.addEventListener('message', function(event) {
+  ch1.addEventListener('message', function(event) {
     clearTimeout(timeout);
     if (event.data !== 'world') {
       reportFatal();
@@ -63,13 +63,13 @@ function runConnectivityTest(iceCandidateFilter, config) {
     }
   });
   call.pc2.addEventListener('datachannel', function(event) {
-    call.pc2.channel = event.channel;
-    call.pc2.channel.addEventListener('message', function(event) {
+    var ch2 = event.channel;
+    ch2.addEventListener('message', function(event) {
       if (event.data !== 'hello') {
         clearTimeout(timeout);
         reportFatal();
       } else {
-        call.pc2.channel.send('world');
+        ch2.send('world');
       }
     });
   });

--- a/src/js/nettest.js
+++ b/src/js/nettest.js
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source

--- a/src/js/nettest.js
+++ b/src/js/nettest.js
@@ -1,0 +1,106 @@
+/*
+ *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+'use strict';
+
+addTest(testSuiteName.NETWORK, testCaseName.UDPENABLED,
+    udpConnectivityTest);
+addTest(testSuiteName.NETWORK, testCaseName.TCPENABLED,
+    tcpConnectivityTest);
+addTest(testSuiteName.NETWORK, testCaseName.IPV6ENABLED,
+    hasIpv6CandidatesTest);
+
+// Test whether it can connect via UDP to a TURN server
+// Get a TURN config, and try to get a relay candidate using UDP.
+function udpConnectivityTest() {
+  Call.asyncCreateTurnConfig(
+      function(config) {
+        filterConfig(config, 'udp');
+        gatherCandidates(config, null, Call.isRelay);
+      },
+      reportFatal);
+}
+
+// Test whether it can connect via TCP to a TURN server
+// Get a TURN config, and try to get a relay candidate using TCP.
+function tcpConnectivityTest() {
+  Call.asyncCreateTurnConfig(
+      function(config) {
+        filterConfig(config, 'tcp');
+        gatherCandidates(config, null, Call.isRelay);
+      },
+      reportFatal);
+}
+
+// Test whether it is IPv6 enabled (TODO: test IPv6 to a destination).
+// Turn on IPv6, and try to get an IPv6 host candidate.
+function hasIpv6CandidatesTest() {
+  var params = {optional: [{googIPv6: true}]};
+  gatherCandidates(null, params, Call.isIpv6);
+}
+
+// Filter the RTCConfiguration |config| to only contain URLs with the
+// specified transport protocol |protocol|. If no turn transport is
+// specified it is added with the requested protocol.
+function filterConfig(config, protocol) {
+  var transport = 'transport=' + protocol;
+  for (var i = 0; i < config.iceServers.length; ++i) {
+    var iceServer = config.iceServers[i];
+    var newUrls = [];
+    for (var j = 0; j < iceServer.urls.length; ++j) {
+      var uri = iceServer.urls[j];
+      if (uri.indexOf(transport) !== -1) {
+        newUrls.push(uri);
+      } else if (uri.indexOf('?transport=') === -1 && uri.startsWith('turn')) {
+        newUrls.push(uri + '?' + transport);
+      }
+    }
+    iceServer.urls = newUrls;
+  }
+}
+
+// Create a PeerConnection, and gather candidates using RTCConfig |config|
+// and ctor params |params|. Succeed if any candidates pass the |isGood|
+// check, fail if we complete gathering without any passing.
+function gatherCandidates(config, params, isGood) {
+  var pc;
+  try {
+    pc = new RTCPeerConnection(config, params);
+  } catch (error) {
+    return reportFatal('Fail to create peer connection: ' + error);
+  }
+
+  // In our candidate callback, stop if we get a candidate that passes |isGood|.
+  pc.onicecandidate = function(e) {
+    // Once we've decided, ignore future callbacks.
+    if (pc.signalingState === 'closed') {
+      return;
+    }
+
+    if (e.candidate) {
+      var parsed = Call.parseCandidate(e.candidate.candidate);
+      if (isGood(parsed)) {
+        reportSuccess('Gathered candidate with type: ' + parsed.type +
+                      ' address: ' + parsed.address);
+        pc.close();
+        setTestFinished();
+      }
+    } else {
+      pc.close();
+      reportFatal('Failed to gather specified candidates');
+    }
+  };
+
+  // Create an audio-only, recvonly offer, and setLD with it.
+  // This will trigger candidate gathering.
+  var createOfferParams = {mandatory: {OfferToReceiveAudio: true}};
+  pc.createOffer(function(offer) { pc.setLocalDescription(offer, noop, noop) ;},
+                 noop, createOfferParams);
+}
+
+function noop() {
+}

--- a/src/js/testcasename.js
+++ b/src/js/testcasename.js
@@ -24,8 +24,8 @@ function TestCaseNames() {
     IPV6ENABLED: 'Ipv6 enabled',
     NETWORKLATENCY: 'Network latency',
     NETWORKLATENCYRELAY: 'Network latency - Relay',
-    UDPCONNECTIVITY: 'Udp connectivity',
-    TCPCONNECTIVITY: 'Tcp connectivity',
+    UDPENABLED: 'Udp enabled',
+    TCPENABLED: 'Tcp enabled',
     VIDEOBANDWIDTH: 'Video bandwidth'
   };
   return this.testCases;

--- a/src/js/testcasename.js
+++ b/src/js/testcasename.js
@@ -26,7 +26,10 @@ function TestCaseNames() {
     NETWORKLATENCYRELAY: 'Network latency - Relay',
     UDPENABLED: 'Udp enabled',
     TCPENABLED: 'Tcp enabled',
-    VIDEOBANDWIDTH: 'Video bandwidth'
+    VIDEOBANDWIDTH: 'Video bandwidth',
+    RELAYCONNECTIVITY: 'Relay connectivity',
+    REFLEXIVECONNECTIVITY: 'Reflexive connectivity',
+    HOSTCONNECTIVITY: 'Host connectivity'
   };
   return this.testCases;
 }

--- a/src/js/testsuitename.js
+++ b/src/js/testsuitename.js
@@ -20,7 +20,8 @@ function TestSuiteNames() {
     CAMERA: 'Camera',
     MICROPHONE: 'Microphone',
     NETWORK: 'Network',
-    CONNECTIVITY: 'Connectivity'
+    CONNECTIVITY: 'Connectivity',
+    THROUGHPUT: 'Throughput'
   };
   return this.testSuites;
 }

--- a/src/js/testsuitename.js
+++ b/src/js/testsuitename.js
@@ -19,6 +19,7 @@ function TestSuiteNames() {
   this.testSuites = {
     CAMERA: 'Camera',
     MICROPHONE: 'Microphone',
+    NETWORK: 'Network',
     CONNECTIVITY: 'Connectivity'
   };
   return this.testSuites;

--- a/src/ui/testrtc-main.html
+++ b/src/ui/testrtc-main.html
@@ -74,6 +74,11 @@
       </div>
 
       <div class="section">
+        <h3>STUN</h3>
+        <paper-input label="URI" always-float-label placeholder="E.g.: stun:myserver.com:3478" value="{{settings.stunURI}}"></paper-input>
+      </div>
+
+      <div class="section">
         <p>For convenience here is a link with these settings:</p>
         <div class="link"><a href="[[_link]]">[[_link]]</a></div>
       </div>


### PR DESCRIPTION
I discovered this project while trying to troubleshoot a specific WebRTC connectivity issue - host to host behind the same NAT. Currently testrtc only appears to test WebRTC connectivity through a relay, leaving out the server reflexive and host scenarios. This pull request adds tests for these scenarios, and reduces possible confusion by splitting out the network capability tests and throughput tests into their own suites.

See #125 for prior relevant discussion.

cc @KaptenJansson @andresusanopinto