### PR TITLE
Pass test object to mic test

### DIFF
--- a/src/js/mictest.js
+++ b/src/js/mictest.js
@@ -182,11 +182,10 @@ MicTest.prototype = {
       var dBPeak = this.dBFS(maxPeak);
       var dBRms = this.dBFS(maxRms);
       this.test.reportInfo('Channel ' + channelNumber + ' levels: ' +
-                 dBPeak.toFixed(1) + ' dB (peak), ' +
-                 dBRms.toFixed(1) + ' dB (RMS)');
+          dBPeak.toFixed(1) + ' dB (peak), ' + dBRms.toFixed(1) + ' dB (RMS)');
       if (dBRms < this.lowVolumeThreshold) {
         this.test.reportError('Microphone input level is low, increase input ' +
-                    'volume or move closer to the microphone.');
+            'volume or move closer to the microphone.');
       }
       if (maxClipCount > this.clipCountThreshold) {
         this.test.reportWarning('Clipping detected! Microphone input level ' +

--- a/src/ui/testrtc-test.html
+++ b/src/ui/testrtc-test.html
@@ -128,7 +128,8 @@
         this.state = "running";
         this.traceTestEvent({name: this.name, status: this.state});
         if (!this.isDisabled) {
-          this.testFunction();
+          // Pass in the "this" object for test reporting and control.
+          this.testFunction(this);
         } else {
           this.reportInfo('Test is disabled.');
           this.done();
@@ -136,6 +137,9 @@
       },
 
       done: function() {
+        if (this.state !== "running") {
+          return;
+        }
         this.setProgress(null);
         var success =
           (this.errorCount + this.warningCount === 0 && this.successCount > 0);


### PR DESCRIPTION
As an FYI this is the first PR part of a series of PR's focusing on reducing globals in TestRTC, specifically it passes the test object from testrtc-test.html to the test so that it can set test status and report directly rather than using the report<status> & setTestFinished() globals.

Also as side objective I will reformat some comments, try to reduce leaking peerConnections (where applicable) and fix other performance issues.

So this means one PR per test.