### PR TITLE
Pass test object to camrestest + remove resolution loop test

### DIFF
--- a/src/js/camresolutionstest.js
+++ b/src/js/camresolutionstest.js
@@ -37,14 +37,14 @@ addTest(testSuiteName.CAMERA, testCaseName.CHECKRESOLUTION720, function(test) {
 });
 
 addTest(
-  testSuiteName.CAMERA,testCaseName.CHECKSUPPORTEDRESOLUTIONS, function(test) {
-    var resolutionArray = [
-      [160, 120], [320, 180], [320, 240], [640, 360], [640, 480], [768, 576],
-      [1024, 576], [1280, 720], [1280, 768], [1280, 800], [1920, 1080],
-      [1920, 1200], [3840, 2160], [4096, 2160]
-    ];
-    var camResolutionsTest = new CamResolutionsTest(test, resolutionArray);
-    camResolutionsTest.run();
+  testSuiteName.CAMERA, testCaseName.CHECKSUPPORTEDRESOLUTIONS, function(test) {
+  var resolutionArray = [
+    [160, 120], [320, 180], [320, 240], [640, 360], [640, 480], [768, 576],
+    [1024, 576], [1280, 720], [1280, 768], [1280, 800], [1920, 1080],
+    [1920, 1200], [3840, 2160], [4096, 2160]
+  ];
+  var camResolutionsTest = new CamResolutionsTest(test, resolutionArray);
+  camResolutionsTest.run();
 });
 
 function CamResolutionsTest(test, resolutions) {

--- a/src/js/camresolutionstest.js
+++ b/src/js/camresolutionstest.js
@@ -13,22 +13,6 @@
  * might support only one resolution.
  */
 
-// Each resolution has width, height and 'mandatory' fields.
-var resolutions = [[160, 120, false],
-                   [320, 180, false],
-                   [320, 240, true],
-                   [640, 360, false],
-                   [640, 480, true],
-                   [768, 576, false],  // PAL
-                   [1024, 576, false],
-                   [1280, 720, true],
-                   [1280, 768, false],
-                   [1280, 800, false],
-                   [1920, 1080, false],  // Full HD
-                   [1920, 1200, false],
-                   [3840, 2160, false],  // 4K
-                   [4096, 2160, false]];
-
 /*
  * "Analyze performance for "resolution"" test uses getStats, canvas and the
  * video element to analyze the video frames from a capture device. It will
@@ -36,148 +20,109 @@ var resolutions = [[160, 120, false],
  * like average encode time and FPS. A test case will be created per mandatory
  * resolution found in the "resolutions" array.
  */
-for (var index = 0; index < resolutions.length; index++) {
-  if (resolutions[index][2]) {
-    var testTitle = testCaseName.CHECKRESOLUTION + resolutions[index][0] + 'x' +
-                    resolutions[index][1];
-    addTest(testSuiteName.CAMERA, testTitle,
-        cameraTest_.bind(null, [resolutions[index]]));
-  }
-}
 
-/*
- * "Supported resolutions" test tries calling getUserMedia() with each
- * resolution from the list below. Each gUM() call triggers a success or a fail
- * callback; we report ok/nok and schedule another gUM() with the next
- * resolution until the list is exhausted. Some resolutions are mandatory and
- * make the test fail if not supported.
- */
-addTest(testSuiteName.CAMERA, testCaseName.CHECKSUPPORTEDRESOLUTION,
-    cameraTest_.bind(null, resolutions));
+addTest(testSuiteName.CAMERA, testCaseName.CHECKRESOLUTION240, function(test) {
+  var camResolutionsTest = new CamResolutionsTest(test);
+  camResolutionsTest.run([320, 240]);
+});
 
-function cameraTest_(resolutions) {
-  var test = new CamResolutionsTest(resolutions);
-  test.run();
-}
+addTest(testSuiteName.CAMERA, testCaseName.CHECKRESOLUTION480, function(test) {
+  var camResolutionsTest = new CamResolutionsTest(test);
+  camResolutionsTest.run([640, 480]);
+});
 
-function CamResolutionsTest(resolutionArray) {
-  this.resolutions = resolutionArray;
+addTest(testSuiteName.CAMERA, testCaseName.CHECKRESOLUTION720, function(test) {
+  var camResolutionsTest = new CamResolutionsTest(test);
+  camResolutionsTest.run([1280, 720]);
+});
+
+function CamResolutionsTest(test) {
+  this.test = test;
   this.mandatoryUnsupportedResolutions = 0;
-  this.numResolutions = this.resolutions.length;
   this.counter = 0;
   this.supportedResolutions = 0;
   this.unsupportedResolutions = 0;
   this.currentResolutionForCheckEncodeTime = null;
-
   this.isMuted = false;
-  this.stream = null;
-}
-
-function resolutionMatchesIndependentOfRotationOrCrop_(aWidth, aHeight,
-                                                       bWidth, bHeight) {
-  var minRes = Math.min(bWidth, bHeight);
-  return (aWidth === bWidth && aHeight === bHeight) ||
-         (aWidth === bHeight && aHeight === bWidth) ||
-         (aWidth === minRes && bHeight === minRes);
 }
 
 CamResolutionsTest.prototype = {
-  run: function() { this.triggerGetUserMedia_(this.resolutions[0]); },
-
-  triggerGetUserMedia_: function(resolution) {
+  run: function(resolution) {
     var constraints = {
       audio: false,
-      video: {
-        mandatory: {
-          minWidth:  resolution[0],
-          minHeight: resolution[1],
-          maxWidth:  resolution[0],
-          maxHeight: resolution[1]
-        }
-      }
+      video: {width: {exact: resolution[0]}, height: {exact: resolution[1]}}
     };
-    try {
-      doGetUserMedia(constraints, this.successFunc_.bind(this),
-          this.failFunc_.bind(this));
-    } catch (e) {
-      reportFatal('GetUserMedia failed.');
-    }
+    navigator.mediaDevices.getUserMedia(constraints)
+    .then(function(stream) {
+      this.collectAndAnalyzeStats_(stream, resolution);
+    }.bind(this))
+    .catch(function(error) {
+      this.test.reportError('getUserMedia failed with error: ' + error);
+      this.test.done();
+    }.bind(this));
   },
 
-  successFunc_: function(stream) {
-    this.stream = stream;
-    this.supportedResolutions++;
-    var selectedResolution = this.resolutions[this.counter++];
-    // Measure performance only when testing one resolution.
-    if (selectedResolution[2] && this.numResolutions === 1) {
-      this.collectAndAnalyzeStats_(stream, selectedResolution);
-    } else {
-      reportInfo('Supported ' + selectedResolution[0] + 'x' +
-                 selectedResolution[1]);
-      stream.getVideoTracks()[0].stop();
-      this.finishTestOrRetrigger_();
-    }
-  },
-
-  collectAndAnalyzeStats_: function(stream, selectedResolution) {
+  collectAndAnalyzeStats_: function(stream, resolution) {
     var tracks = stream.getVideoTracks();
     if (tracks.length < 1) {
-      reportError('No video track in returned stream.');
+      this.test.reportError('No video track in returned stream.');
       this.finishTestOrRetrigger_();
       return;
     }
 
     var videoTrack = tracks[0];
     // Register events.
-    videoTrack.onended = function() {
-      reportError('Video track ended, camera stopped working');
-    };
-    videoTrack.onmute = function() {
-      reportError('Your camera reported itself as muted.');
+    videoTrack.addEventListener('ended', function() {
+      this.test.reportError('Video track ended, camera stopped working');
+    });
+    videoTrack.addEventListener('mute', function() {
+      this.test.reportError('Your camera reported itself as muted.');
       // MediaStreamTrack.muted property is not wired up in Chrome yet, checking
       // isMuted local state.
       this.isMuted = true;
-    };
-    videoTrack.onunmute = function() {
+    });
+    videoTrack.addEventListener('unmute', function() {
       this.isMuted = false;
-    };
+    });
 
     var video = document.createElement('video');
     video.setAttribute('autoplay', '');
     video.setAttribute('muted', '');
     window.videoElement = video;
     window.stream = stream;
-    video.width = selectedResolution[0];
-    video.height = selectedResolution[1];
+    video.width = resolution[0];
+    video.height = resolution[1];
     attachMediaStream(video, stream);
     var frameChecker = new VideoFrameChecker(video);
     var call = new Call();
     call.pc1.addStream(stream);
     call.establishConnection();
     call.gatherStats(call.pc1,
-                     this.onCallEnded_.bind(this, selectedResolution, video,
-                                            this.stream, frameChecker),
+                     this.onCallEnded_.bind(this, resolution, video,
+                                            stream, frameChecker),
                      100);
 
     setTimeoutWithProgressBar(call.close.bind(call), 8000);
   },
 
-  onCallEnded_: function(selectedResolution, videoElement, stream, frameChecker,
+  onCallEnded_: function(resolution, videoElement, stream, frameChecker,
                          stats, statsTime) {
-    this.analyzeStats_(selectedResolution, videoElement, stream, frameChecker,
+    this.analyzeStats_(resolution, videoElement, stream, frameChecker,
                        stats, statsTime);
-
-    this.stream.getVideoTracks()[0].onended = null;
-    this.stream.getVideoTracks()[0].onmute = null;
-    this.stream.getVideoTracks()[0].onunmute = null;
-    this.stream.getVideoTracks()[0].stop();
 
     frameChecker.stop();
 
-    this.finishTestOrRetrigger_();
+    stream.getTracks().forEach(function(track) {
+      track.onended = null;
+      track.onmute = null;
+      track.onunmute = null;
+      track.stop();
+    });
+
+    this.test.done();
   },
 
-  analyzeStats_: function(selectedResolution, videoElement, stream,
+  analyzeStats_: function(resolution, videoElement, stream,
                           frameChecker, stats, statsTime) {
     var googAvgEncodeTime = [];
     var googAvgFrameRateInput = [];
@@ -202,8 +147,8 @@ CamResolutionsTest.prototype = {
     statsReport.cameraName = stream.getVideoTracks()[0].label || NaN;
     statsReport.actualVideoWidth = videoElement.videoWidth;
     statsReport.actualVideoHeight = videoElement.videoHeight;
-    statsReport.mandatoryWidth = selectedResolution[0];
-    statsReport.mandatoryHeight = selectedResolution[1];
+    statsReport.mandatoryWidth = resolution[0];
+    statsReport.mandatoryHeight = resolution[1];
     statsReport.encodeSetupTimeMs =
         this.extractEncoderSetupTime_(stats, statsTime);
     statsReport.avgEncodeTimeMs = arrayAverage(googAvgEncodeTime);
@@ -238,6 +183,14 @@ CamResolutionsTest.prototype = {
     return NaN;
   },
 
+  resolutionMatchesIndependentOfRotationOrCrop_: function(aWidth, aHeight,
+                                                       bWidth, bHeight) {
+    var minRes = Math.min(bWidth, bHeight);
+    return (aWidth === bWidth && aHeight === bHeight) ||
+           (aWidth === bHeight && aHeight === bWidth) ||
+           (aWidth === minRes && bHeight === minRes);
+  },
+
   testExpectations_: function(info) {
     var notAvailableStats = [];
     for (var key in info) {
@@ -245,76 +198,42 @@ CamResolutionsTest.prototype = {
         if (typeof info[key] === 'number' && isNaN(info[key])) {
           notAvailableStats.push(key);
         } else {
-          reportInfo(key + ': ' + info[key]);
+          this.test.reportInfo(key + ': ' + info[key]);
         }
       }
     }
     if (notAvailableStats.length !== 0) {
-      reportInfo('Not available: ' + notAvailableStats.join(', '));
+      this.test.reportInfo('Not available: ' + notAvailableStats.join(', '));
     }
 
     if (isNaN(info.avgSentFps)) {
-      reportInfo('Cannot verify sent FPS.');
+      this.test.reportInfo('Cannot verify sent FPS.');
     } else if (info.avgSentFps < 5) {
-      reportError('Low average sent FPS: ' + info.avgSentFps);
+      this.test.reportError('Low average sent FPS: ' + info.avgSentFps);
     } else {
-      reportSuccess('Average FPS above threshold');
+      this.test.reportSuccess('Average FPS above threshold');
     }
-    if (!resolutionMatchesIndependentOfRotationOrCrop_(info.actualVideoWidth,
-                                                       info.actualVideoHeight,
-                                                       info.mandatoryWidth,
-                                                       info.mandatoryHeight)) {
-      reportError('Incorrect captured resolution.');
+    if (!this.resolutionMatchesIndependentOfRotationOrCrop_(
+        info.actualVideoWidth, info.actualVideoHeight, info.mandatoryWidth,
+        info.mandatoryHeight)) {
+      this.test.reportError('Incorrect captured resolution.');
     } else {
-      reportSuccess('Captured video using expected resolution.');
+      this.test.reportSuccess('Captured video using expected resolution.');
     }
     if (info.testedFrames === 0) {
-      reportError('Could not analyze any video frame.');
+      this.test.reportError('Could not analyze any video frame.');
     } else {
       if (info.blackFrames > info.testedFrames / 3) {
-        reportError('Camera delivering lots of black frames.');
+        this.test.reportError('Camera delivering lots of black frames.');
       }
       if (info.frozenFrames > info.testedFrames / 3) {
-        reportError('Camera delivering lots of frozen frames.');
+        this.test.reportError('Camera delivering lots of frozen frames.');
       }
-    }
-  },
-
-  failFunc_: function() {
-    this.unsupportedResolutions++;
-    var selectedResolution = this.resolutions[this.counter++];
-    if (selectedResolution[2]) {
-      this.mandatoryUnsupportedResolutions++;
-      reportError('Camera does not support a mandatory resolution: ' +
-                  selectedResolution[0] + 'x' + selectedResolution[1]);
-    } else {
-      reportInfo('NOT supported ' + selectedResolution[0] + 'x' +
-                 selectedResolution[1]);
-    }
-    this.finishTestOrRetrigger_();
-  },
-
-  finishTestOrRetrigger_: function() {
-    if (this.counter === this.numResolutions) {
-      if (this.mandatoryUnsupportedResolutions === 0) {
-        if (this.supportedResolutions) {
-          // Assume analyze video performance path if only one resolution.
-          if (this.numResolutions > 1) {
-            reportSuccess(this.supportedResolutions + '/' +
-                          this.numResolutions + ' resolutions supported.');
-          }
-        } else {
-          reportError('No camera resolutions supported, most likely the ' +
-                      'camera is not accessible or dead.');
-        }
-      }
-      setTestFinished();
-    } else {
-      this.triggerGetUserMedia_(this.resolutions[this.counter]);
     }
   }
 };
 
+//TODO: Move this to a separate file.
 function VideoFrameChecker(videoElement) {
   this.frameStats = {
     numFrozenFrames: 0,

--- a/src/js/camresolutionstest.js
+++ b/src/js/camresolutionstest.js
@@ -36,15 +36,15 @@ addTest(testSuiteName.CAMERA, testCaseName.CHECKRESOLUTION720, function(test) {
   camResolutionsTest.run();
 });
 
-addTest(testSuiteName.CAMERA, testCaseName.CHECKSUPPORTEDRESOLUTIONS,
-  function(test) {
-  var resolutionArray = [
+addTest(
+  testSuiteName.CAMERA,testCaseName.CHECKSUPPORTEDRESOLUTIONS, function(test) {
+    var resolutionArray = [
       [160, 120], [320, 180], [320, 240], [640, 360], [640, 480], [768, 576],
       [1024, 576], [1280, 720], [1280, 768], [1280, 800], [1920, 1080],
       [1920, 1200], [3840, 2160], [4096, 2160]
-  ];
-  var camResolutionsTest = new CamResolutionsTest(test, resolutionArray);
-  camResolutionsTest.run();
+    ];
+    var camResolutionsTest = new CamResolutionsTest(test, resolutionArray);
+    camResolutionsTest.run();
 });
 
 function CamResolutionsTest(test, resolutions) {

--- a/src/js/testcasename.js
+++ b/src/js/testcasename.js
@@ -21,6 +21,7 @@ function TestCaseNames() {
     CHECKRESOLUTION240: 'Check resolution 320x240',
     CHECKRESOLUTION480: 'Check resolution 640x480',
     CHECKRESOLUTION720: 'Check resolution 1280x720',
+    CHECKSUPPORTEDRESOLUTIONS: 'Check supported resolutions',
     DATATHROUGHPUT: 'Data throughput',
     IPV6ENABLED: 'Ipv6 enabled',
     NETWORKLATENCY: 'Network latency',

--- a/src/js/testcasename.js
+++ b/src/js/testcasename.js
@@ -18,8 +18,9 @@
 function TestCaseNames() {
   this.testCases = {
     AUDIOCAPTURE: 'Audio capture',
-    CHECKSUPPORTEDRESOLUTION: 'Check supported resolutions',
-    CHECKRESOLUTION: 'Check resolution: ',
+    CHECKRESOLUTION240: 'Check resolution 320x240',
+    CHECKRESOLUTION480: 'Check resolution 640x480',
+    CHECKRESOLUTION720: 'Check resolution 1280x720',
     DATATHROUGHPUT: 'Data throughput',
     IPV6ENABLED: 'Ipv6 enabled',
     NETWORKLATENCY: 'Network latency',


### PR DESCRIPTION
Test object is now passed to the tests, also I've changed the tests to be more explicit, i.e. no more looping through an array of resolutions. It just runs the explicit resolutions test and verifies that there are non black moving pixels coming from the camera.

@tednakamura @samdutton @juberti Do you have anything against me removing the test that checks that gUM is successful for 14 resolutions? It actually prevents it from being run properly on Chrome on Android, it crashes Chrome on this test every time since the last 3 or 4 of milestones (since Camera API v2 was introduced I believe). In my opinion it's more of a stress test than anything else.
