### PR TITLE
Make ipv6 failure a warning

### DIFF
--- a/src/js/nettest.js
+++ b/src/js/nettest.js
@@ -98,14 +98,13 @@ function gatherCandidates(config, params, isGood) {
       }
     } else {
       pc.close();
-      if (!params.optional[0].googIPv6) {
+      if (params.optional[0].googIPv6) {
         reportWarning('Failed to gather IPv6 candidates, it ' +
           'might not be setup/supported on the network.');
-        setTestFinished();
       } else {
         reportError('Failed to gather specified candidates');
-        setTestFinished();
       }
+      setTestFinished();
     }
   });
 


### PR DESCRIPTION
Fixed logical error which prevented the Ipv6 test failure being reported as a warning.

Fixes #139 