### PR TITLE
Host connectivity test should not invlove the relay

### DIFF
--- a/src/js/conntest.js
+++ b/src/js/conntest.js
@@ -31,7 +31,7 @@ addTest(testSuiteName.CONNECTIVITY, testCaseName.REFLEXIVECONNECTIVITY,
 addTest(
   testSuiteName.CONNECTIVITY, testCaseName.HOSTCONNECTIVITY, function(test) {
   var runConnectivityTest =  new RunConnectivityTest(test, Call.isHost);
-  runConnectivityTest.run();
+  runConnectivityTest.start();
 });
 
 function RunConnectivityTest(test, iceCandidateFilter) {


### PR DESCRIPTION
Fixes #150

This used to be the way it worked but was changed in b04bd05902830089aaced1b0663b79a365bd539e, @KaptenJansson assuming this was not on purpose?