### PR TITLE
break out test teardown to a separate function

### DIFF
--- a/src/js/camresolutionstest.js
+++ b/src/js/camresolutionstest.js
@@ -146,10 +146,10 @@ CamResolutionsTest.prototype = {
 
     frameChecker.stop();
 
+    this.test.done();
     stream.getTracks().forEach(function(track) {
       track.stop();
     });
-    this.test.done();
   },
 
   analyzeStats_: function(resolution, videoElement, stream,


### PR DESCRIPTION
fixes #149.

If I remember correctly, previously the code removed all events associated with the video track before calling test done in order to prevent a race condition where on fast machines this.test.done() was executed before the forEach loop finishes and the ended event could not be caught before the object got destroyed, however on slower machines the forEach loop finishes and stops the track thus firing the ended event before this.test.done() is executed and voila, the event has time to fire off an reportError call this failing the test.

Rather than setting all event listeners to null, I just reversed the order to stop the test before stopping the tracks, WDYT? Is this okay or should I explicitly set all events to null in the forEach loop?