### PR TITLE
Adding firefox beta to allowed failure due to the download location returns 404

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
 
   allow_failures:
     - env: BROWSER=chrome  BVER=unstable
+    - env: BROWSER=firefox BVER=beta
 
 before_script:
   - npm install


### PR DESCRIPTION
I'm leaving it as an allowed failure so that we can monitor it, when it's green I will remove it from allowed failures.