### PR TITLE
use new createOffer constraints format

### DIFF
--- a/src/js/nettest.js
+++ b/src/js/nettest.js
@@ -127,7 +127,7 @@ NetworkTest.prototype = {
   // Create an audio-only, recvonly offer, and setLD with it.
   // This will trigger candidate gathering.
   createAudioOnlyReceiveOffer: function(pc) {
-    var createOfferParams = {offerToReceiveAudio: true};
+    var createOfferParams = {offerToReceiveAudio: 1};
     pc.createOffer(function(offer) {
       pc.setLocalDescription(offer, noop, noop);
     }, noop, createOfferParams);

--- a/src/js/nettest.js
+++ b/src/js/nettest.js
@@ -127,7 +127,7 @@ NetworkTest.prototype = {
   // Create an audio-only, recvonly offer, and setLD with it.
   // This will trigger candidate gathering.
   createAudioOnlyReceiveOffer: function(pc) {
-    var createOfferParams = {mandatory: {OfferToReceiveAudio: true}};
+    var createOfferParams = {offerToReceiveAudio: true};
     pc.createOffer(function(offer) {
       pc.setLocalDescription(offer, noop, noop);
     }, noop, createOfferParams);


### PR DESCRIPTION
Firefox beta no longer support the old createOffer constraints format. I will update this in other repos as well.