### PR TITLE
Fix SDP mangling, fix reportFatal in call.js, use latest webrtc-adapter from NPM rather than bower

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
             'app.yaml',
             'testrtc.py',
             'src/manual/**',
-            'components/webrtc-adapter/adapter.js',
+            'node_modules/webrtc-adapter/out/adapter.js',
             'src/images/**'
             ],
             dest: 'out',

--- a/app.yaml
+++ b/app.yaml
@@ -18,8 +18,8 @@ handlers:
   static_dir: src/manual
   secure: always
 
-- url: /components
-  static_dir: components
+- url: /node_modules
+  static_dir: node_modules
   secure: always
 
 - url: /js

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,6 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "polymer": "Polymer/polymer#~1.2.0",
-    "webrtc-adapter": "webrtc/adapter#~0.2.5",
     "paper-toolbar": "PolymerElements/paper-toolbar#~1.0.3",
     "iron-icon": "PolymerElements/iron-icon#~1.0.2",
     "iron-icons": "PolymerElements/iron-icons#~1.0.3",

--- a/build/jshintrc
+++ b/build/jshintrc
@@ -10,6 +10,7 @@
   "undef": true,
   "unused": "strict",
   "globals": {
+    "adapter": true,
     "addExplicitTest": true,
     "addTest": true,
     "arrayAverage": true,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "grunt-htmlhint": "~0.4.1",
     "grunt-jscs": "~1.8.0",
     "grunt-vulcanize": "~1.0.0",
+    "webrtc-adapter": "^1.0.4",
     "webrtc-utilities": ">=0.0.1"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -29,7 +29,7 @@
     ga('send', 'pageview');
   </script>
 
-  <script src="../components/webrtc-adapter/adapter.js"></script>
+  <script src="../node_modules/webrtc-adapter/out/adapter.js"></script>
   <script src="../components/webcomponentsjs/webcomponents-lite.js"></script>
 
   <link rel="import" href="ui/testrtc-main.html">

--- a/src/js/bandwidth_test.js
+++ b/src/js/bandwidth_test.js
@@ -188,7 +188,7 @@ VideoBandwidthTest.prototype = {
   gotStats: function(response) {
     // TODO: Remove browser specific stats gathering hack once adapter.js or
     // browsers converge on a standard.
-    if (webrtcDetectedBrowser === 'chrome') {
+    if (adapter.browserDetails.browser === 'chrome') {
       for (var i in response.result()) {
         var report = response.result()[i];
         if (report.id === 'bweforvideo') {
@@ -203,7 +203,7 @@ VideoBandwidthTest.prototype = {
           this.packetsLost = report.stat('packetsLost');
         }
       }
-    } else if (webrtcDetectedBrowser === 'firefox') {
+    } else if (adapter.browserDetails.browser === 'firefox') {
       for (var j in response) {
         var stats = response[j];
         if (stats.id === 'outbound_rtcp_video_0') {
@@ -237,7 +237,7 @@ VideoBandwidthTest.prototype = {
 
     // TODO: Remove browser specific stats gathering hack once adapter.js or
     // browsers converge on a standard.
-    if (webrtcDetectedBrowser === 'chrome') {
+    if (adapter.browserDetails.browser  === 'chrome') {
       // Checking if greater than 2 because Chrome sometimes reports 2x2 when
       // a camera starts but fails to deliver frames.
       if (this.videoStats[0] < 2 && this.videoStats[1] < 2) {
@@ -254,7 +254,7 @@ VideoBandwidthTest.prototype = {
         this.test.reportInfo('Send bandwidth ramp-up time: ' +
             this.bweStats.getRampUpTime() + ' ms');
       }
-    } else if (webrtcDetectedBrowser === 'firefox') {
+    } else if (adapter.browserDetails.browser  === 'firefox') {
       if (parseInt(this.framerateMean) > 0) {
         this.test.reportSuccess('Frame rate mean: ' +
             parseInt(this.framerateMean));

--- a/src/js/bandwidth_test.js
+++ b/src/js/bandwidth_test.js
@@ -45,7 +45,7 @@ DataChannelThroughputTest.prototype = {
   },
 
   start: function(config) {
-    this.call = new Call(config);
+    this.call = new Call(config, this.test);
     this.call.setIceCandidateFilter(Call.isRelay);
     this.senderChannel = this.call.pc1.createDataChannel(null);
     this.senderChannel.addEventListener('open', this.sendingStep.bind(this));
@@ -152,7 +152,7 @@ VideoBandwidthTest.prototype = {
   },
 
   start: function(config) {
-    this.call = new Call(config);
+    this.call = new Call(config, this.test);
     this.call.setIceCandidateFilter(Call.isRelay);
     // FEC makes it hard to study bandwidth estimation since there seems to be
     // a spike when it is enabled and disabled. Disable it for now. FEC issue
@@ -311,7 +311,7 @@ WiFiPeriodicScanTest.prototype = {
 
   start: function(config) {
     this.running = true;
-    this.call = new Call(config);
+    this.call = new Call(config, this.test);
     this.chart = this.test.createLineChart();
     this.call.setIceCandidateFilter(this.candidateFilter);
 

--- a/src/js/call.js
+++ b/src/js/call.js
@@ -7,7 +7,8 @@
  */
 'use strict';
 
-function Call(config) {
+function Call(config, test) {
+  this.test = test;
   this.traceEvent = report.traceEventAsync('call');
   this.traceEvent({config: config});
 
@@ -25,7 +26,8 @@ function Call(config) {
 Call.prototype = {
   establishConnection: function() {
     this.traceEvent({state: 'start'});
-    this.pc1.createOffer(this.gotOffer_.bind(this), reportFatal);
+    this.pc1.createOffer(this.gotOffer_.bind(this),
+        this.test.reportFatal.bind(this.test));
   },
 
   close: function() {
@@ -85,10 +87,13 @@ Call.prototype = {
                                     '$1\r\n');
       offer.sdp = offer.sdp.replace(/a=rtpmap:116 red\/90000\r\n/g, '');
       offer.sdp = offer.sdp.replace(/a=rtpmap:117 ulpfec\/90000\r\n/g, '');
+      offer.sdp = offer.sdp.replace(/a=rtpmap:98 rtx\/90000\r\n/g, '');
+      offer.sdp = offer.sdp.replace(/a=fmtp:98 apt=116\r\n/g, '');
     }
     this.pc1.setLocalDescription(offer);
     this.pc2.setRemoteDescription(offer);
-    this.pc2.createAnswer(this.gotAnswer_.bind(this), reportFatal);
+    this.pc2.createAnswer(this.gotAnswer_.bind(this),
+        this.test.reportFatal.bind(this.test));
   },
 
   gotAnswer_: function(answer) {

--- a/src/js/camresolutionstest.js
+++ b/src/js/camresolutionstest.js
@@ -84,7 +84,7 @@ CamResolutionsTest.prototype = {
         this.test.reportInfo(resolution[0] + 'x' + resolution[1] +
             ' not supported');
       } else {
-        this.test.reportError('getUserMedia failed with error: ' + error);
+        this.test.reportError('getUserMedia failed with error: ' + error.name);
       }
       this.maybeContinueGetUserMedia();
     }.bind(this));
@@ -144,7 +144,7 @@ CamResolutionsTest.prototype = {
     video.setAttribute('muted', '');
     video.width = resolution[0];
     video.height = resolution[1];
-    attachMediaStream(video, stream);
+    video.srcObject = stream;
     var frameChecker = new VideoFrameChecker(video);
     var call = new Call(null, this.test);
     call.pc1.addStream(stream);

--- a/src/js/camresolutionstest.js
+++ b/src/js/camresolutionstest.js
@@ -146,7 +146,7 @@ CamResolutionsTest.prototype = {
     video.height = resolution[1];
     attachMediaStream(video, stream);
     var frameChecker = new VideoFrameChecker(video);
-    var call = new Call();
+    var call = new Call(null, this.test);
     call.pc1.addStream(stream);
     call.establishConnection();
     call.gatherStats(call.pc1,

--- a/src/js/conntest.js
+++ b/src/js/conntest.js
@@ -49,7 +49,7 @@ RunConnectivityTest.prototype = {
   },
 
   start: function(config) {
-    this.call = new Call(config);
+    this.call = new Call(config, this.test);
     this.call.setIceCandidateFilter(this.iceCandidateFilter);
 
     // Collect all candidates for validation.

--- a/src/manual/audio-and-video/index.html
+++ b/src/manual/audio-and-video/index.html
@@ -16,7 +16,6 @@
   <script src="../../../node_modules/webrtc-adapter/out/adapter.js"></script>
   <script type="text/javascript">
   function requestVideoAndAudio() {
-    // Call into getUserMedia via the polyfill (adapter.js).
     navigator.getUserMedia({video: true, audio: true},
         getUserMediaOkCallback, getUserMediaFailedCallback);
   }

--- a/src/manual/audio-and-video/index.html
+++ b/src/manual/audio-and-video/index.html
@@ -26,8 +26,8 @@
   }
 
   function getUserMediaOkCallback(stream) {
-    adapter.browserShim.attachMediaStream(document.getElementById("view1"), stream);
-    adapter.browserShim.attachMediaStream(document.getElementById("audio1"), stream);
+    document.getElementById("view1").srcObject = stream;
+    document.getElementById("audio1").srcObject = stream;
   }
   </script>
 </head>

--- a/src/manual/audio-and-video/index.html
+++ b/src/manual/audio-and-video/index.html
@@ -13,13 +13,12 @@
   <title>Single Local Preview (Video and Audio)</title>
   <meta http-equiv="X-UA-Compatible" content="chrome=1"/>
   <!-- Load the polyfill to switch-hit between Chrome and Firefox -->
-  <script src="../../../components/webrtc-adapter/adapter.js"></script>
+  <script src="../../../node_modules/webrtc-adapter/out/adapter.js"></script>
   <script type="text/javascript">
   function requestVideoAndAudio() {
     // Call into getUserMedia via the polyfill (adapter.js).
-    getUserMedia({video: true, audio: true},
-                         getUserMediaOkCallback,
-                         getUserMediaFailedCallback);
+    navigator.getUserMedia({video: true, audio: true},
+        getUserMediaOkCallback, getUserMediaFailedCallback);
   }
 
   function getUserMediaFailedCallback(error) {
@@ -27,8 +26,8 @@
   }
 
   function getUserMediaOkCallback(stream) {
-    attachMediaStream(document.getElementById("view1"), stream);
-    attachMediaStream(document.getElementById("audio1"), stream);
+    adapter.browserShim.attachMediaStream(document.getElementById("view1"), stream);
+    adapter.browserShim.attachMediaStream(document.getElementById("audio1"), stream);
   }
   </script>
 </head>

--- a/src/manual/multiple-audio/index.html
+++ b/src/manual/multiple-audio/index.html
@@ -26,9 +26,8 @@
   }
 
   function getUserMediaOkCallback(stream) {
-     // Call the polyfill wrapper to attach the media stream to this element.
     for (var i = 1; i <= 10; i++) {
-      adapter.browserShim.attachMediaStream(document.getElementById("audio" + i), stream);
+      document.getElementById("audio" + i).srcObject = stream;
     }
   }
   </script>

--- a/src/manual/multiple-audio/index.html
+++ b/src/manual/multiple-audio/index.html
@@ -13,13 +13,12 @@
   <title>Multiple Local Preview (Audio Only)</title>
   <meta http-equiv="X-UA-Compatible" content="chrome=1"/>
   <!-- Load the polyfill to switch-hit between Chrome and Firefox -->
-  <script src="../../../components/webrtc-adapter/adapter.js"></script>
+  <script src="../../../node_modules/webrtc-adapter/out/adapter.js"></script>
   <script type="text/javascript">
   function requestAudio() {
     // Call into getUserMedia via the polyfill (adapter.js).
-    getUserMedia({video: false, audio: true},
-                         getUserMediaOkCallback,
-                         getUserMediaFailedCallback);
+    navigator.getUserMedia({video: false, audio: true},
+        getUserMediaOkCallback, getUserMediaFailedCallback);
   }
 
   function getUserMediaFailedCallback(error) {
@@ -29,7 +28,7 @@
   function getUserMediaOkCallback(stream) {
      // Call the polyfill wrapper to attach the media stream to this element.
     for (var i = 1; i <= 10; i++) {
-      attachMediaStream(document.getElementById("audio" + i), stream);
+      adapter.browserShim.attachMediaStream(document.getElementById("audio" + i), stream);
     }
   }
   </script>

--- a/src/manual/multiple-video-devices/index.html
+++ b/src/manual/multiple-video-devices/index.html
@@ -25,7 +25,7 @@
   </div>
   <div id="messages"></div>
    <!-- Load the polyfill to switch-hit between Chrome and Firefox -->
-  <script src="../../../components/webrtc-adapter/adapter.js"></script>
+  <script src="../../../node_modules/webrtc-adapter/out/adapter.js"></script>
   <script src="js/main.js"></script>
 </body>
 </html>

--- a/src/manual/multiple-video-devices/js/main.js
+++ b/src/manual/multiple-video-devices/js/main.js
@@ -31,7 +31,7 @@ function getSources_() {
 }
 
 function requestVideo_(id) {
-  getUserMedia({
+  navigator.getUserMedia({
     video: {optional: [{sourceId: id}]},
     audio: false},
     function(stream) {
@@ -61,7 +61,7 @@ function getUserMediaOkCallback_(stream) {
     div.appendChild(deviceLabel);
   }
   stream.getVideoTracks()[0].addEventListener('ended', errorMessage_);
-  attachMediaStream(document.getElementById('view' + counter), stream);
+  adapter.browserShim.attachMediaStream(document.getElementById('view' + counter), stream);
   counter++;
 }
 

--- a/src/manual/multiple-video-devices/js/main.js
+++ b/src/manual/multiple-video-devices/js/main.js
@@ -61,7 +61,8 @@ function getUserMediaOkCallback_(stream) {
     div.appendChild(deviceLabel);
   }
   stream.getVideoTracks()[0].addEventListener('ended', errorMessage_);
-  adapter.browserShim.attachMediaStream(document.getElementById('view' + counter), stream);
+  adapter.browserShim.attachMediaStream(
+      document.getElementById('view' + counter), stream);
   counter++;
 }
 

--- a/src/manual/multiple-video-devices/js/main.js
+++ b/src/manual/multiple-video-devices/js/main.js
@@ -61,8 +61,7 @@ function getUserMediaOkCallback_(stream) {
     div.appendChild(deviceLabel);
   }
   stream.getVideoTracks()[0].addEventListener('ended', errorMessage_);
-  adapter.browserShim.attachMediaStream(
-      document.getElementById('view' + counter), stream);
+  document.getElementById('view' + counter).srcObject = stream;
   counter++;
 }
 

--- a/src/manual/multiple-video/index.html
+++ b/src/manual/multiple-video/index.html
@@ -47,13 +47,12 @@
           autoplay="autoplay"></video></td>
     </tr>
   </table>
-  <script src="../../../components/webrtc-adapter/adapter.js"></script>
+  <script src="../../../node_modules/webrtc-adapter/out/adapter.js"></script>
   <script type="text/javascript">
     function requestVideo() {
       // Call into getUserMedia via the polyfill (adapter.js).
-      getUserMedia( {video: true, audio: false},
-                    getUserMediaOkCallback,
-                    getUserMediaFailedCallback);
+      navigator.getUserMedia( {video: true, audio: false},
+          getUserMediaOkCallback, getUserMediaFailedCallback);
     }
 
     function getUserMediaFailedCallback(error) {
@@ -63,7 +62,7 @@
     function getUserMediaOkCallback(stream) {
       // Call the polyfill wrapper to attach the media stream to this element.
       for (var i = 1; i <= 10; i++) {
-        attachMediaStream(document.getElementById('view' + i), stream);
+        adapter.browserShim.attachMediaStream(document.getElementById('view' + i), stream);
       }
     }
   </script>

--- a/src/manual/multiple-video/index.html
+++ b/src/manual/multiple-video/index.html
@@ -60,9 +60,8 @@
     }
 
     function getUserMediaOkCallback(stream) {
-      // Call the polyfill wrapper to attach the media stream to this element.
       for (var i = 1; i <= 10; i++) {
-        adapter.browserShim.attachMediaStream(document.getElementById('view' + i), stream);
+        document.getElementById('view' + i).srcObject = stream;
       }
     }
   </script>

--- a/src/manual/peer2peer/index.html
+++ b/src/manual/peer2peer/index.html
@@ -193,7 +193,7 @@
 
   </div>
 </div>
-  <script src="../../../components/webrtc-adapter/adapter.js"></script>
+  <script src="../../../node_modules/webrtc-adapter/out/adapter.js"></script>
   <script src="js/main.js"></script>
 </body>
 </html>

--- a/src/manual/peer2peer/js/main.js
+++ b/src/manual/peer2peer/js/main.js
@@ -852,7 +852,7 @@ function doGetUserMedia_(constraints) {
     if (stream.getVideoTracks().length > 0) {
       // Show the video element if we did request video in the getUserMedia call.
       var videoElement = $('local-view');
-      adapter.browserShim.attachMediaStream(videoElement, stream);
+      videoElement.srcObject = stream;
       window.addEventListener('loadedmetadata', function() {
           displayVideoSize(videoElement);}, true);
       // Throw an error when no video is sent from camera but gUM returns OK.
@@ -958,7 +958,7 @@ function setLocalAndSendMessage_(sessionDescription) {
 function addStreamCallback_(event) {
   print_('Receiving remote stream...');
   var videoElement = document.getElementById('remote-view');
-  adapter.browserShim.attachMediaStream(videoElement, event.stream);
+  videoElement.srcObject = event.stream;
 
   window.addEventListener('loadedmetadata',
       function() {displayVideoSize(videoElement);}, true);

--- a/src/manual/peer2peer/js/main.js
+++ b/src/manual/peer2peer/js/main.js
@@ -852,7 +852,7 @@ function doGetUserMedia_(constraints) {
     if (stream.getVideoTracks().length > 0) {
       // Show the video element if we did request video in the getUserMedia call.
       var videoElement = $('local-view');
-      attachMediaStream(videoElement, stream);
+      adapter.browserShim.attachMediaStream(videoElement, stream);
       window.addEventListener('loadedmetadata', function() {
           displayVideoSize(videoElement);}, true);
       // Throw an error when no video is sent from camera but gUM returns OK.
@@ -958,7 +958,7 @@ function setLocalAndSendMessage_(sessionDescription) {
 function addStreamCallback_(event) {
   print_('Receiving remote stream...');
   var videoElement = document.getElementById('remote-view');
-  attachMediaStream(videoElement, event.stream);
+  adapter.browserShim.attachMediaStream(videoElement, event.stream);
 
   window.addEventListener('loadedmetadata',
       function() {displayVideoSize(videoElement);}, true);

--- a/src/manual/single-audio/index.html
+++ b/src/manual/single-audio/index.html
@@ -13,12 +13,11 @@
   <title>Single Local Preview (Audio Only)</title>
   <meta http-equiv="X-UA-Compatible" content="chrome=1"/>
   <!-- Load the polyfill to switch-hit between Chrome and Firefox -->
-  <script src="../../../components/webrtc-adapter/adapter.js"></script>
+  <script src="../../../node_modules/webrtc-adapter/out/adapter.js"></script>
   <script type="text/javascript">
   function requestAudio() {
-    getUserMedia({video: false, audio: true},
-                         getUserMediaOkCallback,
-                         getUserMediaFailedCallback);
+    navigator.getUserMedia({video: false, audio: true},
+        getUserMediaOkCallback, getUserMediaFailedCallback);
   }
 
   function getUserMediaFailedCallback(error) {
@@ -27,7 +26,7 @@
 
   function getUserMediaOkCallback(stream) {
     // Call the polyfill wrapper to attach the media stream to this element.
-    attachMediaStream(document.getElementById("audio1"), stream);
+    adapter.browserShim.attachMediaStream(document.getElementById("audio1"), stream);
   }
   </script>
 </head>

--- a/src/manual/single-audio/index.html
+++ b/src/manual/single-audio/index.html
@@ -25,8 +25,7 @@
   }
 
   function getUserMediaOkCallback(stream) {
-    // Call the polyfill wrapper to attach the media stream to this element.
-    adapter.browserShim.attachMediaStream(document.getElementById("audio1"), stream);
+    document.getElementById("audio1").srcObject = stream;
   }
   </script>
 </head>

--- a/src/manual/single-video/index.html
+++ b/src/manual/single-video/index.html
@@ -13,12 +13,11 @@
   <title>Single Local Preview (Video Only)</title>
   <meta http-equiv="X-UA-Compatible" content="chrome=1"/>
   <!-- Load the polyfill to switch-hit between Chrome and Firefox -->
-  <script src="../../../components/webrtc-adapter/adapter.js"></script>
+  <script src="../../../node_modules/webrtc-adapter/out/adapter.js"></script>
   <script type="text/javascript">
   function requestVideo() {
-    getUserMedia({video: true, audio: false},
-                         getUserMediaOkCallback,
-                         getUserMediaFailedCallback);
+    navigator.getUserMedia({video: true, audio: false},
+        getUserMediaOkCallback, getUserMediaFailedCallback);
   }
 
   function getUserMediaFailedCallback(error) {
@@ -27,7 +26,7 @@
 
   function getUserMediaOkCallback(stream) {
     // Call the polyfill wrapper to attach the media stream to this element.
-    attachMediaStream(document.getElementById("view1"), stream);
+    adapter.browserShim.attachMediaStream(document.getElementById("view1"), stream);
   }
   </script>
 </head>

--- a/src/manual/single-video/index.html
+++ b/src/manual/single-video/index.html
@@ -25,8 +25,7 @@
   }
 
   function getUserMediaOkCallback(stream) {
-    // Call the polyfill wrapper to attach the media stream to this element.
-    adapter.browserShim.attachMediaStream(document.getElementById("view1"), stream);
+    document.getElementById("view1").srcObject = stream;
   }
   </script>
 </head>

--- a/src/ui/gum-handler.html
+++ b/src/ui/gum-handler.html
@@ -32,7 +32,9 @@ visible on the page but is no more it will keep polling permissions once per sec
       },
       getUserMedia: {
         type: Function,
-        value: function() { return navigator.getUserMedia.bind(navigator); }
+        value: function() {
+          return navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+        }
       },
       enumerateDevices: {
         type: Function,
@@ -78,25 +80,23 @@ visible on the page but is no more it will keep polling permissions once per sec
           }
         }
       }
-      this.getUserMedia(constraints, this.gotStream_.bind(this), this.gotError_.bind(this));
+      this.getUserMedia(constraints)
+      .then(function(stream) {
+        // Stop all tracks to ensure the camera and audio devices are shutdown
+        // directly.
+        for (var i = 0; i < stream.getVideoTracks().length; i++) {
+          stream.getVideoTracks()[i].stop();
+        }
+        for (var j = 0; j < stream.getAudioTracks().length; j++) {
+          stream.getAudioTracks()[j].stop();
+        }
+        this.pending = false;
+        this.error = false;
+      }.bind(this))
+      .catch(function(error) {
+        this.error = error;
+        setTimeout(this.triggerGetUserMedia_.bind(this), 1000);
+      }.bind(this));
     },
-
-    gotStream_: function(stream) {
-      // Stop all tracks to ensure the camera and audio devices are shutdown
-      // directly.
-      for (var i = 0; i < stream.getVideoTracks().length; i++) {
-        stream.getVideoTracks()[i].stop();
-      }
-      for (var j = 0; j < stream.getAudioTracks().length; j++) {
-        stream.getAudioTracks()[j].stop();
-      }
-      this.pending = false;
-      this.error = false;
-    },
-
-    gotError_: function(error) {
-      this.error = error.name;
-      setTimeout(this.triggerGetUserMedia_.bind(this), 1000);
-    }
   });
 </script>

--- a/src/ui/gum-handler.html
+++ b/src/ui/gum-handler.html
@@ -60,7 +60,7 @@ visible on the page but is no more it will keep polling permissions once per sec
       // does not necessarily mean JS device selection is unsupported.
       this.enumerateDevices()
       .then(this.triggerGetUserMediaBasedOnSources_.bind(this))
-      .catch((function(err) {
+          .catch((function(err) {
         console.log('JS Device selection not supported', err);
         this.triggerGetUserMediaBasedOnSources_([]);
       }).bind(this));
@@ -81,7 +81,7 @@ visible on the page but is no more it will keep polling permissions once per sec
         }
       }
       this.getUserMedia(constraints)
-      .then(function(stream) {
+      .then((function(stream) {
         // Stop all tracks to ensure the camera and audio devices are shutdown
         // directly.
         for (var i = 0; i < stream.getVideoTracks().length; i++) {
@@ -92,11 +92,11 @@ visible on the page but is no more it will keep polling permissions once per sec
         }
         this.pending = false;
         this.error = false;
-      }.bind(this))
-      .catch(function(error) {
+      }).bind(this))
+      .catch((function(error) {
         this.error = error;
         setTimeout(this.triggerGetUserMedia_.bind(this), 1000);
-      }.bind(this));
+      }).bind(this));
     },
   });
 </script>

--- a/src/ui/testrtc-main.html
+++ b/src/ui/testrtc-main.html
@@ -135,6 +135,8 @@
         'bug-report': 'openBugReport',
       },
       _pendingChanged: function (pending) {
+        this.traceEnumDevice = report.traceEventAsync('enumerateDevices');
+        adapter.disableLog(true);
         if (pending === false) {
           // Populate the device selection drop down menu after the gUM dialog closes.
           navigator.mediaDevices.enumerateDevices()
@@ -163,7 +165,7 @@
           option.text = sourceInfo.label || 'camera ' + (this.$.videoSource.length + 1);
           this.$.videoSource.appendChild(option);
         } else {
-          console.log('Some other kind of source');
+          this.traceEnumDevice('Some other kind of source: ' + sourceInfo.kind);
         }
       },
 
@@ -171,29 +173,29 @@
         var self = this;
         var traceGumEvent = report.traceEventAsync('getusermedia');
 
-        // Call into getUserMedia via the polyfill (adapter.js).
-        var successFunc = function(stream) {
-          var cam = self.getDeviceName_(stream.getVideoTracks());
-          var mic = self.getDeviceName_(stream.getAudioTracks());
-          traceGumEvent({'status': 'success', 'camera': cam, 'microphone': mic});
-          onSuccess.apply(this, arguments);
-        };
-        var failFunc = function(error) {
-          traceGumEvent({'status': 'fail', 'error': error});
-          if (onFail) {
-            onFail.apply(this, arguments);
-          } else {
-            reportFatal('Failed to get access to local media due to error: ' +
-                        error.name);
-          }
-        };
         try {
           // Append the constraints with the getSource constraints.
           this.appendSourceId(this.$.audioSource.value, 'audio', constraints);
           this.appendSourceId(this.$.videoSource.value, 'video', constraints);
 
           traceGumEvent({'status': 'pending', 'constraints': constraints});
-          getUserMedia(constraints, successFunc, failFunc);
+          // Call into getUserMedia via the polyfill (adapter.js).
+          navigator.mediaDevices.getUserMedia(constraints)
+          .then(function(stream) {
+            var cam = self.getDeviceName_(stream.getVideoTracks());
+            var mic = self.getDeviceName_(stream.getAudioTracks());
+            traceGumEvent({'status': 'success', 'camera': cam, 'microphone': mic});
+            onSuccess.apply(this, arguments);
+          })
+          .catch(function(error) {
+            traceGumEvent({'status': 'fail', 'error': error});
+            if (onFail) {
+              onFail.apply(this, arguments);
+            } else {
+              reportFatal('Failed to get access to local media due to error: ' +
+                          error.name);
+            }
+            });
         } catch (e) {
           console.log(e);
           traceGumEvent({'status': 'exception', 'error': e.message});

--- a/src/ui/testrtc-main.html
+++ b/src/ui/testrtc-main.html
@@ -140,9 +140,9 @@
         if (pending === false) {
           // Populate the device selection drop down menu after the gUM dialog closes.
           navigator.mediaDevices.enumerateDevices()
-          .then(this.gotSources.bind(this))
-          .catch(function(err) {
-            console.log('JS Device selection not supported', err);
+              .then(this.gotSources.bind(this))
+              .catch(function(err) {
+                console.log('JS Device selection not supported', err);
           });
 
           window.doGetUserMedia = this.doGetUserMedia.bind(this);
@@ -181,25 +181,27 @@
           traceGumEvent({'status': 'pending', 'constraints': constraints});
           // Call into getUserMedia via the polyfill (adapter.js).
           navigator.mediaDevices.getUserMedia(constraints)
-          .then(function(stream) {
-            var cam = self.getDeviceName_(stream.getVideoTracks());
-            var mic = self.getDeviceName_(stream.getAudioTracks());
-            traceGumEvent({'status': 'success', 'camera': cam, 'microphone': mic});
-            onSuccess.apply(this, arguments);
-          })
-          .catch(function(error) {
-            traceGumEvent({'status': 'fail', 'error': error});
-            if (onFail) {
-              onFail.apply(this, arguments);
-            } else {
-              reportFatal('Failed to get access to local media due to error: ' +
-                          error.name);
-            }
-            });
+              .then(function(stream) {
+                var cam = self.getDeviceName_(stream.getVideoTracks());
+                var mic = self.getDeviceName_(stream.getAudioTracks());
+                traceGumEvent({'status': 'success', 'camera': cam,
+                    'microphone': mic});
+                onSuccess.apply(this, arguments);
+              })
+              .catch(function(error) {
+                traceGumEvent({'status': 'fail', 'error': error});
+                if (onFail) {
+                  onFail.apply(this, arguments);
+                } else {
+                  reportFatal('Failed to get access to local media due to ' +
+                      'error: ' + error.name);
+                }
+              });
         } catch (e) {
           console.log(e);
           traceGumEvent({'status': 'exception', 'error': e.message});
-          return reportFatal('getUserMedia failed with exception: ' + e.message);
+          return reportFatal('getUserMedia failed with exception: ' +
+              e.message);
         }
       },
 


### PR DESCRIPTION
**Description**
* SDP has changed in Chrome M50 hence there are more video error correction params we need to remove for the bandwidth tests.
* Update and use latest webrtc-adapter from NPM rather than bower.
* Fix reportFatal (dead code) in call.js

Fixes #178 

**Purpose**
Fix errors seen in Chrome M50