### PR TITLE
MediaRecorder: Add media recorder manual test page to testrtc.

### DIFF
--- a/src/manual/index.html
+++ b/src/manual/index.html
@@ -70,6 +70,8 @@
 
       <p><a href="single-video/">Single video stream</a></p>
 
+      <p><a href="media-recorder/">MediaStream Recorder</a></p>
+
     </section>
 
     <a href="//github.com/webrtc/testrtc/tree/master/src/manual" title="View the repository" id="viewSource">github.com/webrtc/testrtc/tree/master/src/manual</a>

--- a/src/manual/media-recorder/index.html
+++ b/src/manual/media-recorder/index.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<!--
+ *  Copyright (c) 2016 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+-->
+<html>
+<head>
+<title>MediaStream Recoder Manual Test</title>
+</head>
+<body>
+  <div> Record Real-Time video test.</div>
+  <video id="local_video" autoplay></video>
+  <video id="remote_video" autoplay></video>
+  <br><strong>GetUserMedia Options</strong></br>
+  <label>Enable Audio</label>
+  <select id="enable_audio">
+    <option value="true">yes</option>
+    <option value="false">no</option>
+  </select>
+  <label>Enable Video</label>
+  <select id="enable_video">
+    <option value="true">yes</option>
+    <option value="false">no</option>
+  </select>
+  <label>Video Resolution</label>
+  <select id="resolution">
+    <option value=""></option>
+    <option value="160x120">160x120</option>
+    <option value="320x240">320x240</option>
+    <option value="640x480">640x480</option>
+    <option value="1280x720">1280x720</option>
+    <option value="1920x1080">1920x1080</option>
+  </select>
+  <br></br>
+  <button onclick="getUserMedia();">GetUSerMedia</button>
+  <button onclick="stopStream(theLocalStream);">StopLocalStream</button>
+  <button onclick="stopStream(theLocalStream, 'video');">StopLocalVideoTrack
+  </button>
+  <button onclick="stopStream(theLocalStream, 'audio');">StopLocalAudioTracks
+  </button>
+  <button onclick="stopStream(theRemoteStream);">StopRemoteStream</button>
+  <button onclick="stopStream(theRemoteStream, 'video');">StopRemoteVideoTrack
+  </button>
+  <button onclick="stopStream(theRemoteStream, 'audio');">StopRemoteAudioTracks
+  </button>
+  <br></br>
+  <br><strong>Local Peer Connection</strong></br>
+  <button onclick="createPeerConnection();">CreatePeerConnection</button>
+  <br></br>
+  <br><strong>Recorder Options</strong></br>
+  <label>Stream To Record</label>
+  <select id="recorded_stream">
+    <option value="remote">remote</option>
+    <option value="local">local</option>
+  </select>
+  <label>Audio BitRate</label>
+  <select id="audio_bitrate">
+    <option value=""></option>
+    <option value="96000">96kpbs</option>
+    <option value="128000">128kbps</option>
+    <option value="160000">160kbps</option>
+    <option value="192000">192kbps</option>
+    <option value="256000">256kbps</option>
+    <option value="400000">400kbps</option>
+  </select>
+  <label>Video Codec</label>
+  <select id="video_codec">
+    <option value=""></option>
+    <option value="VP8">VP8</option>
+    <option value="VP9">VP9</option>
+  </select>
+  <label>Video Bitrate</label>
+  <select id="video_bitrate">
+    <option value=""></option>
+    <option value="16000">16kpbs</option>
+    <option value="128000">128kbps</option>
+    <option value="160000">160kbps</option>
+    <option value="192000">192kbps</option>
+    <option value="256000">256kbps</option>
+    <option value="384000">384kbps</option>
+    <option value="400000">400kbps</option>
+    <option value="750000">750kbps</option>
+    <option value="1000000">1Mbps</option>
+    <option value="2500000">2.5Mbps</option>
+    <option value="3500000">3.5Mbps</option>
+    <option value="6800000">6.8Mbps</option>
+    <option value="9800000">9.8Mbps</option>
+    <option value="15000000">15Mbps</option>
+  </select>
+  <label>Overall Bitrate</label>
+  <select id="overall_av_bitrate">
+    <option value=""></option>
+    <option value="128000">128kbps</option>
+    <option value="160000">160kbps</option>
+    <option value="192000">192kbps</option>
+    <option value="256000">256kbps</option>
+    <option value="384000">384kbps</option>
+    <option value="400000">400kbps</option>
+    <option value="750000">750kbps</option>
+    <option value="1000000">1Mbps</option>
+    <option value="2500000">2.5Mbps</option>
+    <option value="3500000">3.5Mbps</option>
+    <option value="6800000">6.8Mbps</option>
+    <option value="9800000">9.8Mbps</option>
+    <option value="15000000">15Mbps</option>
+  </select>
+  <br></br>
+  <label>Ignore Muted Media</label>
+  <select id="ignore_muted">
+    <option value="true">yes</option>
+    <option value="false">no</option>
+  </select>
+  <br></br>
+  <br><strong>Recorder Controls</strong></br>
+  <button onclick="createRecorder();">CreateRecorder</button>
+  <label>Monitor Recorder's Event Counts</label>
+  <select id="monitor_events" onchange="monitorRecorderEvents(this.value);">
+    <option value=""></option>
+    <option value="all">all events</option>
+    <option value="onstart">onstart</option>
+    <option value="onstop">onstop</option>
+    <option value="onpause">onpause</option>
+    <option value="onresume">onresume</option>
+    <option value="onerror">onerror</option>
+  </select>
+  <br></br>
+  <label>Time slice</label>
+  <select id="time_slice">
+    <option value=""></option>
+    <option value="100">100ms</option>
+    <option value="200">200ms</option>
+    <option value="1000">1s</option>
+    <option value="10000">10s</option>
+    <option value="100000">100s</option>
+    <option value="1000000">1,000s</option>
+    <option value="1800000">30 min</option>
+    <option value="3600000">1 hour</option>
+    <option value="7200000">2 hours</option>
+    <option value="86400000">24 hours</option>
+  </select>
+  <button onclick="startRecorder();">Start</button>
+  <button onclick="pauseRecorder();">Pause</button>
+  <button onclick="resumeRecorder();">Resume</button>
+  <button onclick="stopRecorder();">Stop</button>
+  <button onclick="requestDataRecorder();">RequestData</button>
+  <br></br>
+  <br><strong>Playback Controls</strong></br>
+  <button onclick="playback();">Playback</button>
+  <button onclick="download();">Download</button>
+  <br>
+    <video id="playback_video" autoplay></video>
+  </br>
+  <br><strong>Recorder State</strong></br>
+  <label>RecorderState: </label>
+  <textarea id="recorder_state" readonly rows=1 cols=10>N/A</textarea>
+  <br></br>
+  <br><strong>Recorder's Event Counters and metrics</strong></br>
+  <label>onstart: </label>
+  <textarea id="onstart_count" readonly rows=1 cols=10>0</textarea>
+  <label>onstop: </label>
+  <textarea id="onstop_count" readonly rows=1 cols=10>0</textarea>
+  <label>onpause: </label>
+  <textarea id="onpause_count" readonly rows=1 cols=10>0</textarea>
+  <label>onresume: </label>
+  <textarea id="onresume_count" readonly rows=1 cols=10>0</textarea>
+  <label>ondataavailable: </label>
+  <textarea id="ondataavailable_count" readonly rows=1 cols=10>0</textarea>
+  <label>onerror: </label>
+  <textarea id="onerror_count" readonly rows=1 cols=10>0</textarea>
+  <label>bitrate: </label>
+  <textarea id ="bitrate_estimate" readonly rows=1 cols=10>N/A</textarea>
+</body>
+<script src="js/main.js"> </script>
+</body>
+</html>

--- a/src/manual/media-recorder/js/main.js
+++ b/src/manual/media-recorder/js/main.js
@@ -1,0 +1,382 @@
+/*
+*  Copyright (c) 2016 The WebRTC project authors. All Rights Reserved.
+*
+*  Use of this source code is governed by a BSD-style license
+*  that can be found in the LICENSE file in the root of the source
+*  tree.
+*/
+
+'use strict';
+var theLocalStream = null;
+var theRemoteStream = null;
+var theRecorder = null;
+var eventsMonitored = null;
+// Note: ondataavailable is not in the list below because it is necessary to
+// have it always on if we ever want to playbabk/download the recording in a
+// consistent manner.
+var RECORDER_EVENTS = ['onstart', 'onpause', 'onresume', 'onstop', 'onerror'];
+var eventCounter;
+var recordedData;
+var timeDataReceived;
+
+// This function gets the selected value of a <select> element.
+function getSelectedValue(id) {
+  var e = document.getElementById(id);
+  return e.options[e.selectedIndex].value;
+}
+
+// This function builds the basic gUM constraints from the
+// selected GetUserMedia options in html.
+function buildConstraints(audioEnabled, videoEnabled, resolution) {
+  var constraints = {audio: false, video: false};
+  var res = resolution.split('x');
+  var width = res[0];
+  var height = res[1];
+  if (height && videoEnabled) {
+    constraints.video = {mandatory: {
+      minWidth: width,
+      minHeight: height,
+      maxWidth: width,
+      maxHeight: height
+    }};
+  } else if (videoEnabled) {
+    constraints.video = true;
+  }
+  if (audioEnabled) {
+    constraints.audio = true;
+  }
+  return constraints;
+}
+
+// This function returns true if the string provided is equal to 'true'.
+// Otherwise it returns false.
+function isTrue(someString) {
+ if (someString == 'true') {
+   return true;
+ } else {
+   return false;
+ }
+}
+
+// This function performs a gUM request and populates the local stream as
+// well as the local_video tag.
+function getUserMedia() {
+ var enableAudio = isTrue(getSelectedValue('enable_audio'));
+ var enableVideo = isTrue(getSelectedValue('enable_video'));
+ var resolution = getSelectedValue('resolution');
+ var constraints = buildConstraints(enableAudio, enableVideo, resolution);
+
+ navigator.mediaDevices.getUserMedia(constraints)
+    .then(function(stream) {
+      document.getElementById('local_video').src = URL.createObjectURL(stream);
+      theLocalStream = stream;
+    });
+}
+
+// This function stops a either a whole stream, or video tracks or audio tracks
+// from that stream.
+function stopStream(stream, tracksType) {
+  return new Promise(function(resolve, reject) {
+    var tracks = null;
+    if (!stream) {
+      alert('Stream is not initialized!');
+      reject();
+    }
+    if (tracksType == 'video') {
+      tracks = stream.getVideoTracks();
+    } else if (tracksType == 'audio') {
+      tracks = stream.getAudioTracks();
+    } else {
+      tracks = stream.getTracks();
+    }
+    tracks.forEach(function(track) {
+        track.stop();
+    });
+    resolve();
+  });
+}
+
+// This function builds the media recorder's configuration.
+function buildRecorderConfig() {
+  var options = {};
+  var stream = getSelectedValue('recorded_stream');
+  var audioBitrate = getSelectedValue('audio_bitrate');
+  var videoCodec = getSelectedValue('video_codec');
+  var videoBitrate = getSelectedValue('video_bitrate');
+  var overallBitrate = getSelectedValue('overall_av_bitrate');
+  if (stream == 'local') {
+    stream = theLocalStream;
+  } else {
+    stream = theRemoteStream;
+  }
+  if (!stream) {
+    return null;
+  }
+  if (audioBitrate && !overallBitrate) {
+    options.audioBitsPerSecond = audioBitrate;
+  }
+  if (videoBitrate && !overallBitrate) {
+    options.videoBitsPerSecond = videoBitrate;
+  }
+  if (overallBitrate) {
+    options.bitsPerSecond = overallBitrate;
+  }
+  if (videoCodec) {
+    options.mimeType = 'video/webm; codecs="' + videoCodec + '"';
+  }
+  return [stream, options];
+}
+
+// This function creates the media recorder instance, configures the
+// ignoreMutedMedia parameter and sets a handler to save the recording.
+function createRecorder() {
+  var config = buildRecorderConfig();
+  var ON_DATA_AVAILABLE = 'ondataavailable';
+  if (!config) {
+    alert('Cannot create recorder without a stream!');
+    return;
+  }
+  var stream = config[0];
+  var options = config[1];
+  var ignoreMutedMedia = isTrue(getSelectedValue('ignore_muted'));
+  createMediaRecorderInstance(stream, options)
+      .then(function(recorder) {
+        theRecorder = recorder;
+        theRecorder.ignoreMutedMedia = ignoreMutedMedia;
+        theRecorder[ON_DATA_AVAILABLE] = function(event) {
+            computeAndDisplayEventCount(ON_DATA_AVAILABLE);
+            if (event.data && event.data.size > 0) {
+              recordedData.push(event.data);
+              timeDataReceived.push(new Date());
+            }};
+        // Keep track of recorder state in UI every 500ms.
+        setInterval(function() {displayRecorderState();}, 500);
+      });
+}
+
+// This function starts the media recorder.
+// If a time slice is selected, the function will configure the
+// recorder time slice when starting recorder.
+function startRecorder() {
+  if (!theRecorder) {
+    alert('Recorder not initialized!');
+    return;
+  }
+  recordedData = [];
+  timeDataReceived = [];
+  eventCounter = {};
+  var timeSlice = getSelectedValue('time_slice');
+  if (timeSlice) {
+    theRecorder.start(timeSlice);
+  } else {
+    theRecorder.start();
+  }
+  displayRecorderState();
+}
+
+// This function pauses the media recorder.
+function pauseRecorder() {
+  if (!theRecorder) {
+    alert('Recorder not initialized!');
+    return;
+  }
+  theRecorder.pause();
+  displayRecorderState();
+}
+
+// This function resumes the media recorder.
+function resumeRecorder() {
+  if (!theRecorder) {
+    alert('Recorder not initialized!');
+    return;
+  }
+  theRecorder.resume();
+  displayRecorderState();
+}
+
+// This function stops the media recorder.
+function stopRecorder() {
+  if (!theRecorder) {
+    alert('Recorder not initialized!');
+    return;
+  }
+  theRecorder.stop();
+  displayRecorderState();
+  displayBitrateEstimate();
+}
+
+// This function requests a blob from media recorder.
+function requestDataRecorder() {
+  if (!theRecorder) {
+    alert('Recorder not initialized!');
+    return;
+  }
+  theRecorder.requestData();
+}
+
+// This function configures the event handlers of media recorder.
+function monitorRecorderEvents(eventName) {
+  if (!theRecorder) {
+    alert('No recorder initialized!');
+    return;
+  }
+  if (eventsMonitored) {
+    recorderEventHandlersAction('remove', eventsMonitored);
+  }
+  if (eventName)
+    recorderEventHandlersAction('add', eventName);
+  eventsMonitored = eventName;
+}
+
+// This function adds/removes the recorder's event handlers.
+function recorderEventHandlersAction(action, eventName) {
+  var events = [];
+  if (eventName == 'all') {
+    events = RECORDER_EVENTS;
+  } else {
+    events = [eventName];
+  }
+  events.forEach(function(event) {
+      if (action == 'remove') {
+        theRecorder[event] = null;
+        computeAndDisplayEventCount(event, true);
+      } else {
+        theRecorder[event] = function() {computeAndDisplayEventCount(event);};
+      }
+  });
+}
+
+// This function computes and displays the recorder events counts.
+function computeAndDisplayEventCount(eventName, initialize) {
+  // TODO(cpaulin): see if this can be used for more than the event counts.
+  if (initialize) {
+    eventCounter[eventName] = 0;
+  } else if (eventCounter[eventName]) {
+    eventCounter[eventName] += 1;
+  } else {
+    eventCounter[eventName] = 1;
+  }
+  document.getElementById(eventName + '_count').value = eventCounter[eventName];
+}
+
+// This function displays the media recoder's state.
+function displayRecorderState() {
+  document.getElementById('recorder_state').value = theRecorder.state;
+}
+
+// This function attempts to estimate the overall bitrate of the recording.
+// It then displays the estimate in UI.
+function displayBitrateEstimate() {
+  var dataSize = 0;
+  recordedData.forEach(function(data) {
+    dataSize += data.size;
+  });
+  var deltaTime = timeDataReceived.pop() - timeDataReceived.shift();
+  if (!deltaTime)
+    return;
+  // Time is in ms, size is in bytes.
+  var bitrateEstimate = dataSize / deltaTime * 8 * 1000;
+  document.getElementById('bitrate_estimate').value = bitrateEstimate;
+}
+
+// This function playsback the recording.
+function playback() {
+  if (!recordedData.length) {
+    alert('No recording found!');
+    return;
+  }
+  var videoBlob = new Blob(recordedData, {type: 'video/webm'});
+  playback_video.src = window.URL.createObjectURL(videoBlob);
+}
+
+function download() {
+  if (!recordedData.length) {
+    alert('No recording found!');
+    return;
+  }
+  var videoBlob = new Blob(recordedData, {type: 'video/webm'});
+  var url = window.URL.createObjectURL(videoBlob);
+  var downloader = document.createElement('a');
+  downloader.style.display = 'none';
+  downloader.href = url;
+  downloader.download = 'test.webm';
+  document.body.appendChild(downloader);
+  downloader.click();
+  setTimeout(function() {
+    document.body.removeChild(downloader);
+    window.URL.revokeObjectURL(url);
+  }, 100);
+}
+
+// This function creates the local peer connection and saves the
+// remote stream object.
+function createPeerConnection(stream) {
+  if (!theLocalStream) {
+    alert('No local stream initialized!');
+    return;
+  }
+  setupPeerConnection(theLocalStream)
+      .then(function(stream) {
+        theRemoteStream = stream;
+      })
+      .catch(function(error) {
+        alert('Peer Connection setup failed: ' + error);
+      });
+}
+
+// This function is called by createPeerConnection and is responsible for the
+// actual setting of the local peer connection.
+function setupPeerConnection(stream) {
+  return new Promise(function(resolve, reject) {
+    var localStream = stream;
+    var remoteStream = null;
+    var localPeerConnection = new webkitRTCPeerConnection(null);
+    var remotePeerConnection = new webkitRTCPeerConnection(null);
+
+    function createAnswer(description) {
+      remotePeerConnection.createAnswer(function(description) {
+        remotePeerConnection.setLocalDescription(description);
+        localPeerConnection.setRemoteDescription(description);
+      }, function(error) { alert(error.toString()); });
+    }
+
+    if (!localStream)
+      reject('Stream not initialized!!');
+
+    localPeerConnection.onicecandidate = function(event) {
+      if (event.candidate) {
+        remotePeerConnection.addIceCandidate(new RTCIceCandidate(
+            event.candidate));
+      }
+    };
+    remotePeerConnection.onicecandidate = function(event) {
+      if (event.candidate) {
+        localPeerConnection.addIceCandidate(new RTCIceCandidate(
+            event.candidate));
+      }
+    };
+    remotePeerConnection.onaddstream = function(event) {
+      document.getElementById('remote_video').src = URL.createObjectURL(
+          event.stream);
+      remoteStream = event.stream;
+      resolve(remoteStream);
+    };
+
+    localPeerConnection.addStream(localStream);
+
+    localPeerConnection.createOffer(function(description) {
+      localPeerConnection.setLocalDescription(description);
+      remotePeerConnection.setRemoteDescription(description);
+      createAnswer(description);
+    }, function(error) { alert(error.toString()); });
+  });
+}
+
+// This function creates a media recorder instance.
+function createMediaRecorderInstance(stream, options) {
+  return new Promise(function(resolve, reject) {
+    var recorder = new MediaRecorder(stream, options);
+    console.log('Recorder object created.');
+    resolve(recorder);
+  });
+}


### PR DESCRIPTION
**Description**
MediaRecorder: Add media recorder manual test page to testrtc.

**Purpose**

This CL adds a manual test page for media recorder.
All the parameters of media recorder are configurable in this
test page. Also the user can choose to record the local stream or
a remote peer connection (loopback) stream. The promise version
of gUM is needed for this to work properly.