### PR TITLE
Improve stats collection in call.js

### DIFF
--- a/src/js/call.js
+++ b/src/js/call.js
@@ -55,7 +55,7 @@ Call.prototype = {
   gatherStats: function(peerConnection, localStream, statsCb) {
     var stats = [];
     var statsCollectTime = [];
-    var that = this;
+    var self = this;
     var statStepMs = 100;
     // Firefox does not handle the mediaStream object directly, either |null|
     // for all stats or mediaStreamTrack, which is according to the standard: https://www.w3.org/TR/webrtc/#widl-RTCPeerConnection-getStats-void-MediaStreamTrack-selector-RTCStatsCallback-successCallback-RTCPeerConnectionErrorCallback-failureCallback
@@ -75,9 +75,9 @@ Call.prototype = {
       peerConnection.getStats(selector)
           .then(gotStats_)
           .catch(function(error) {
-            that.test.reportError('Could not gather stats: ' + error);
+            self.test.reportError('Could not gather stats: ' + error);
             statsCb(stats, statsCollectTime);
-          }.bind(that));
+          }.bind(self));
     }
 
     function gotStats_(response) {
@@ -95,7 +95,7 @@ Call.prototype = {
           statsCollectTime.push(Date.now());
         }
       } else {
-        that.test.reportError('Only Firefox and Chrome getStats ' +
+        self.test.reportError('Only Firefox and Chrome getStats ' +
             'implementations are supported.');
       }
       setTimeout(getStats_, statStepMs);

--- a/src/js/call.js
+++ b/src/js/call.js
@@ -75,7 +75,8 @@ Call.prototype = {
       peerConnection.getStats(selector)
           .then(gotStats_)
           .catch(function(error) {
-            that.test.reportFatal('Could not gather stats: ' + error);
+            that.test.reportError('Could not gather stats: ' + error);
+            statsCb(stats, statsCollectTime);
           }.bind(that));
     }
 

--- a/src/js/camresolutionstest.js
+++ b/src/js/camresolutionstest.js
@@ -149,7 +149,7 @@ CamResolutionsTest.prototype = {
     var call = new Call(null, this.test);
     call.pc1.addStream(stream);
     call.establishConnection();
-    call.gatherStats(call.pc1,
+    call.gatherStats(call.pc1, stream,
                      this.onCallEnded_.bind(this, resolution, video,
                                             stream, frameChecker),
                      100);


### PR DESCRIPTION
**Description**
Fix getStats error

**Purpose**
Make it run on Firefox

I do want to improve it further so that all tests can use the gatherStats method in call.js but I will do that in a separate PR to keep it simple.
