### PR TITLE
Update to adapter 1.1.0 and use call.js for all stats gathering

### DIFF
--- a/src/js/camresolutionstest.js
+++ b/src/js/camresolutionstest.js
@@ -175,16 +175,16 @@ CamResolutionsTest.prototype = {
     var statsReport = {};
     var frameStats = frameChecker.frameStats;
 
-    for (var index = 0; index < stats.length - 1; index++) {
+    for (var index in stats) {
       if (stats[index].type === 'ssrc') {
         // Make sure to only capture stats after the encoder is setup.
-        if (stats[index].stat('googFrameRateInput') > 0) {
+        if (parseInt(stats[index].googFrameRateInput) > 0) {
           googAvgEncodeTime.push(
-              parseInt(stats[index].stat('googAvgEncodeMs')));
+              parseInt(stats[index].googAvgEncodeMs));
           googAvgFrameRateInput.push(
-              parseInt(stats[index].stat('googFrameRateInput')));
+              parseInt(stats[index].googFrameRateInput));
           googAvgFrameRateSent.push(
-              parseInt(stats[index].stat('googFrameRateSent')));
+              parseInt(stats[index].googFrameRateSent));
         }
       }
     }
@@ -228,7 +228,7 @@ CamResolutionsTest.prototype = {
   extractEncoderSetupTime_: function(stats, statsTime) {
     for (var index = 0; index !== stats.length; index++) {
       if (stats[index].type === 'ssrc') {
-        if (stats[index].stat('googFrameRateInput') > 0) {
+        if (parseInt(stats[index].googFrameRateInput) > 0) {
           return JSON.stringify(statsTime[index] - statsTime[0]);
         }
       }


### PR DESCRIPTION
**Description**
Use latest adapter.js
Fix yet another issue when gathering stats on firefox (found when updating adapter).
Refactored bandwidth_test.js and cameraresolutiontest.js to use call.js for gathering stats.

**Purpose**
Get the latest adapter.js shimming
Having the stats gathering logic on one place makes it easier update.
