### PR TITLE
Request Audio With Desktop Share Only When The User Approves

### DIFF
--- a/src/manual/peer2peer/extension/background.js
+++ b/src/manual/peer2peer/extension/background.js
@@ -32,10 +32,11 @@ function requestScreenSharing(port, msg) {
   //  - 'streamId' String that can be passed to getUserMedia() API
   desktopMediaRequestId =
       chrome.desktopCapture.chooseDesktopMedia(dataSources, port.sender.tab,
-          function(streamId) {
+          function(streamId, options) {
             if (streamId) {
               msg.type = 'SS_DIALOG_SUCCESS';
               msg.streamId = streamId;
+              msg.requestAudio = options && options.canRequestAudioTrack;
             } else {
               msg.type = 'SS_DIALOG_CANCEL';
             }

--- a/src/manual/peer2peer/js/main.js
+++ b/src/manual/peer2peer/js/main.js
@@ -412,7 +412,8 @@ function screenCaptureExtensionHandler_() {
     if (event.data.type && (event.data.type === 'SS_DIALOG_SUCCESS')) {
       var audioConstraint =
         (adapter.browserDetails.browser === 'chrome' &&
-            adapter.browserDetails.version >= 50) ? {
+            adapter.browserDetails.version >= 50 && 
+            event.data.requestAudio) ? {
           mandatory: {
             chromeMediaSource: 'desktop',
             chromeMediaSourceId: event.data.streamId


### PR DESCRIPTION
**Description**
We found that mediaDevices.getUserMedia does a strong check for the existence of requested track.
Namely, if we request an audio track, but Chromium cannot provide, getUserMedia will throw an exception rather than return a video-only stream. This behavior is aligned with the spec definition.

However, this brings some inconvenience in the desktop share with audio area, because on the media picker dialog, the end user could choose to uncheck the audio checkbox, and wish to get a video only stream. To resolve this dilemma, we change the Chromium a little bit to pass the information whether the user has checked or unchecked the audio to the callback function of chooseDesktopMedia, and then let following Javascript react correctly.

This change makes the mannual/peer2peer react correctly based on the newly added parameter.
