### PR TITLE
all: remove references to jshint and jscs

### DIFF
--- a/src/js/call.js
+++ b/src/js/call.js
@@ -268,10 +268,6 @@ Call.fetchTurnConfig_ = function(onSuccess, onError) {
   xhr.onreadystatechange = onResult;
   // API_KEY and TURN_URL is replaced with API_KEY environment variable via
   // Gruntfile.js during build time by uglifyJS.
-  // jscs:disable
-  /* jshint ignore:start */
   xhr.open('POST', TURN_URL + API_KEY, true);
-  // jscs:enable
-  /* jshint ignore:end */
   xhr.send();
 };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -5,10 +5,8 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
-
-/* More information about these options at jshint.com/docs/options */
-/* exported addExplicitTest, addTest, audioContext */
 'use strict';
+/* exported addExplicitTest, addTest, audioContext */
 
 // Global WebAudio context that can be shared by all tests.
 // There is a very finite number of WebAudio contexts.

--- a/src/js/ssim.js
+++ b/src/js/ssim.js
@@ -5,8 +5,6 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
-
-/* More information about these options at jshint.com/docs/options */
 'use strict';
 
 /* This is an implementation of the algorithm for calculating the Structural

--- a/src/js/videoframechecker.js
+++ b/src/js/videoframechecker.js
@@ -5,9 +5,8 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
-
-/* More information about these options at jshint.com/docs/options */
 'use strict';
+
 function VideoFrameChecker(videoElement) {
   this.frameStats = {
     numFrozenFrames: 0,

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -5,9 +5,6 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
-/* jshint node: true */
-/* globals require */
-
 'use strict';
 var test = require('tape');
 

--- a/test/sanity-test.js
+++ b/test/sanity-test.js
@@ -5,11 +5,10 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
-
 'use strict';
+
 // This is a basic test file for use with testling.
 // The test script language comes from tape.
-/* jshint node: true */
 var test = require('tape');
 
 var webdriver = require('selenium-webdriver');


### PR DESCRIPTION
this got replaced by eslint a while ago