### PR TITLE
bandwidth test: PLI is picture loss indication

### DIFF
--- a/src/js/bandwidth_test.js
+++ b/src/js/bandwidth_test.js
@@ -270,8 +270,8 @@ VideoBandwidthTest.prototype = {
         this.test.reportInfo('Packets sent: ' + this.packetsSent);
         this.test.reportInfo('Packets received: ' + this.packetsReceived);
         this.test.reportInfo('NACK count: ' + this.nackCount);
+        this.test.reportInfo('Picture loss indications: ' + this.pliCount);
         this.test.reportInfo('Quality predictor sum: ' + this.qpSum);
-        this.test.reportInfo('Packet loss indicator: ' + this.pliCount);
         this.test.reportInfo('Frames encoded: ' + this.framesEncoded);
         this.test.reportInfo('Frames decoded: ' + this.framesDecoded);
       }


### PR DESCRIPTION
not packet loss indication. See https://tools.ietf.org/html/rfc4585
Arguably, it is an indication for severe packet loss.

@henbos I heard you know a bit about this "statistics" stuff, can you review?