### PR TITLE
Fix Dead links in testrtc description - Issue #247

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,6 @@ Due to their time duration they are not part of the normal test suite and need t
 * [Network latency](https://test.webrtc.org/?test_filter=Network%20latency)
   * Establishs a loopback call and sends very small packets (via data channels) during 5 minutes plotting them to the user. It can be used to identify issues on the network.
 
-## Other manual test pages ##
-* [Audio and Video streams](https://test.webrtc.org/manual/audio-and-video/)
-* [Iframe apprtc](https://test.webrtc.org/manual/iframe-apprtc/)
-* [Iframe video](https://test.webrtc.org/manual/iframe-video/)
-* [Multiple audio streams](https://test.webrtc.org/manual/multiple-audio/)
-* [Multiple peerconnections](https://test.webrtc.org/manual/multiple-peerconnections/)
-* [Multiple video devices](https://test.webrtc.org/manual/multiple-video-devices/)
-* [Multiple video streams](https://test.webrtc.org/manual/multiple-video/)
-* [Peer2peer](https://test.webrtc.org/manual/peer2peer/)
-* [Peer2peer iframe](https://test.webrtc.org/manual/peer2peer-iframe/)
-* [Single audio stream](https://test.webrtc.org/manual/single-audio/)
-* [Single video stream](https://test.webrtc.org/manual/single-video/)
-
 ## Contributing ##
 Pull requests and issues welcome! See [CONTRIBUTING](https://github.com/GoogleChrome/webrtc/blob/master/CONTRIBUTING.md) for instructions. All contributors must sign a contributor license agreement before code can be accepted. Please complete the agreement for an [individual](https://developers.google.com/open-source/cla/individual) or a [corporation](https://developers.google.com/open-source/cla/corporate) as appropriate. The [Developer's Guide](https://bit.ly/webrtcdevguide) for this repo has more information about code style, structure and validation.
 


### PR DESCRIPTION
**Description**
Removed "Other test pages section" from README.md file

**Purpose**
Fix Dead links in testrtc description - that takes users to 404.